### PR TITLE
Update .gitignore and package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 .idea/
+package-lock.json
 
 # User-specific files
-*.package-lock.json
 *.rsuser
 *.suo
 *.user

--- a/package.json
+++ b/package.json
@@ -11,6 +11,18 @@
         "type": "git",
         "url": "https://github.com/accouter/accouter.git"
     },
+    "keywords": [
+        "css",
+        "sass",
+        "scss",
+        "flexbox",
+        "grid",
+        "responsive",
+        "framework"
+    ],
+    "bugs": {
+        "url": "https://github.com/accouter/accouter/issues"
+    },
     "devDependencies": {
         "cssnano": "^6.1.2",
         "postcss-cli": "^11.0.0",


### PR DESCRIPTION
Ignore package-lock.json files globally and add new keywords and bug reporting link to package.json file. The added keywords will help improve package discoverability, while the bug reporting link will provide users a direct channel for reporting issues.