### PR TITLE
Added build scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "description": "",
     "license": "MIT",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "build": "npm run build-accouter",
+        "build-accouter": "sass --style=expanded --source-map accouter.scss css/accouter.css"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Two new scripts have been added to the package.json. These scripts enable the building of the application via `npm run build`, and specifically for accouter styling with `npm run build-accouter`.