### PR TITLE
Update build scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
     "description": "",
     "license": "MIT",
     "scripts": {
-        "build": "npm run build-accouter",
-        "build-accouter": "sass --style=expanded --source-map accouter.scss css/accouter.css"
+        "build": "npm run build-scss && npm run build-minify",
+        "build-scss": "sass --style=expanded --source-map accouter.scss css/accouter.css",
+        "build-minify": "postcss css/accouter.css --no-map --use cssnano --output css/accouter.min.css"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
The build scripts in package.json have been updated to separate SCSS compilation and CSS minification. The "build" command now runs both the "build-scss" and "build-minify" scripts in sequence, generating both expanded and minimized CSS files from the SCSS source.