### PR TITLE
Theme shades

### DIFF
--- a/scss/configs/variables-derived.scss
+++ b/scss/configs/variables-derived.scss
@@ -53,6 +53,8 @@ $size-normal:       vi.$size-6 !default;
 $size-medium:       vi.$size-5 !default;
 $size-large:        vi.$size-4 !default;
 
+$sizes:             vi.$size-1 vi.$size-2 vi.$size-3 vi.$size-4 vi.$size-5 vi.$size-6 vi.$size-7 !default;
+
 // Effects
 $shadow-color:      vi.$black !default;
 
@@ -73,3 +75,16 @@ $colors:            fn.mergeColorMaps((
   "warning": $warning,
   "danger": $danger,
 ), $custom-colors) !default;
+
+$shades:            fn.mergeColorMaps((
+  "black-bis": vi.$black-bis,
+  "black-ter": vi.$black-ter,
+  "gray-darker": vi.$gray-darker,
+  "gray-dark": vi.$gray-dark,
+  "gray": vi.$gray,
+  "gray-light": vi.$gray-light,
+  "gray-lighter": vi.$gray-lighter,
+  "gray-lightest": vi.$gray-lightest,
+  "white-ter": vi.$white-ter,
+  "white-bis": vi.$white-bis,
+), $custom-shades) !default;

--- a/scss/configs/variables-scss.scss
+++ b/scss/configs/variables-scss.scss
@@ -76,9 +76,9 @@
     }
   }
 
-  $on-scheme-lightness: lightness($on-scheme-color);
+  $on-scheme-lightness:    lightness($on-scheme-color);
   @include register-var($name, $on-scheme-lightness, "", "-on-scheme-l");
-  $on-scheme-l: getVar($name, "", "-on-scheme-l");
+  $on-scheme-l:            getVar($name, "", "-on-scheme-l");
   @include register-var(#{$name}-on-scheme, buildHsla($name, $on-scheme-l));
 }
 
@@ -119,6 +119,37 @@
   @include register-base-color($name, $base);
 
   // Generate 20 shades of color
+  @if ($l-base < 3%) {
+    $l-0: $l-base;
+    $l-5: $l-base + 5%;
+  } @else if ($l-base < 8%) {
+    $l-0: $l-base - 5%;
+    $l-5: $l-base;
+  } @else {
+    $l-0: $l-base - 10%;
+    $l-5: $l-base - 5%;
+  }
+
+  $shades:             ();
+
+  @for $i from 0 through 9 {
+    // if $l-base = 3%, then we get 3%, 13%, 23% etc
+    $color-l-0: math.max($l-0 + $i * 10, 0%);
+    // if $l-base = 3%, then we get 8%, 18%, 28% etc
+    $color-l-5: $l-5 + $i * 10;
+
+    $shades: map.set($shades, $i, #{$i}0, $color-l-0);
+    $shades: map.set($shades, $i, #{$i}5, $color-l-5);
+
+    @include register-var($name, $color-l-0, "", "-#{$i}0-l");
+    @include register-var($name, $color-l-5, "", "-#{$i}5-l");
+
+    @if $color-l-0 == $l {
+      $base-digits: #{$i}0;
+    } @else if $color-l-5 == $l {
+      $base-digits: #{$i}5;
+    }
+  }
 }
 
 @mixin accouter-theme($name) {

--- a/scss/configs/variables-scss.scss
+++ b/scss/configs/variables-scss.scss
@@ -115,7 +115,10 @@
   $pct-to-int:         math.div($closest-5, 100%) * 100;
   $scheme-main-digits: #{$pct-to-int};
 
+  // Register base color
   @include register-base-color($name, $base);
+
+  // Generate 20 shades of color
 }
 
 @mixin accouter-theme($name) {

--- a/scss/themes/light.scss
+++ b/scss/themes/light.scss
@@ -113,5 +113,18 @@ $scheme-main:   hsl(vi.$scheme-h, vi.$scheme-s, $scheme-main-l);
     }
 
     @include vs.generate-on-scheme-colors($name, $base, $scheme-main);
+
+    // Shades
+    @each $name, $shade in vd.$shades{
+      @include vs.register-var($name, $shade);
+    }
+
+    @include vs.register-hsl("shadow", vd.$shadow-color);
+
+    @each $size in vd.$sizes{
+      $i: index(vd.$sizes, $size);
+      $name: "size-#{$i}";
+      @include vs.register-var($name, $size);
+    }
   }
 }


### PR DESCRIPTION
In the relevant derived SCSS configuration file, we've added a new $sizes variable, comprising several existing size variables. We've also introduced a $shades variable that includes numerous shade-related color variables. This addition provides centralized access and control over size and color variables used across the application's SCSS stylesheets.

The light theme has been extended with the addition of various color shades and sizes. The variables-scss configuration file also received updates, where registration of base color was added along with the generation of 20 shades of color.
@wangkanai
