### PR TITLE
Add function min() and max() replacement for container

### DIFF
--- a/scss/configs/functions.scss
+++ b/scss/configs/functions.scss
@@ -131,3 +131,19 @@
 
   @return "bright";
 }
+
+@function min($value1, $value2) {
+  @if $value1 < $value2 {
+    @return $value2;
+  }
+
+  @return $value1;
+}
+
+@function max($value1, $value2) {
+  @if $value1 > $value2 {
+    @return $value2;
+  }
+
+  @return $value1;
+}

--- a/scss/layouts/container.scss
+++ b/scss/layouts/container.scss
@@ -1,5 +1,8 @@
+@use "sass:math";
+
 @use "../configs/variables-init" as vi;
 @use "../configs/mixins" as mx;
+@use "../configs/functions" as fn;
 
 $container-offset:    2 * vi.$gap !default;
 $container-max-width: vi.$fullhd !default;
@@ -23,25 +26,25 @@ $container-max-width: vi.$fullhd !default;
 
   @include mx.until-widescreen {
     &.#{vi.$prefix}is-widescreen:not(.#{vi.$prefix}is-max-desktop) {
-      max-width: min(vi.$widescreen, $container-max-width) - $container-offset;
+      max-width: fn.min(vi.$widescreen, $container-max-width) - $container-offset;
     }
   }
 
   @include mx.until-fullhd {
     &.#{vi.$prefix}is-fullhd:not(.#{vi.$prefix}is-max-desktop):not(.#{vi.$prefix}is-max-widescreen) {
-      max-width: min(vi.$fullhd, $container-max-width) - $container-offset;
+      max-width: fn.min(vi.$fullhd, $container-max-width) - $container-offset;
     }
   }
 
   @include mx.widescreen {
     &:not(.#{vi.$prefix}is-max-desktop) {
-      max-width: min(vi.$widescreen, $container-max-width) - $container-offset;
+      max-width: fn.min(vi.$widescreen, $container-max-width) - $container-offset;
     }
   }
 
   @include mx.fullhd {
     &:not(.#{vi.$prefix}is-max-desktop):not(.#{vi.$prefix}is-max-widescreen) {
-      max-width: min(vi.$fullhd, $container-max-width) - $container-offset;
+      max-width: fn.min(vi.$fullhd, $container-max-width) - $container-offset;
     }
   }
 }

--- a/scss/layouts/container.scss
+++ b/scss/layouts/container.scss
@@ -23,25 +23,25 @@ $container-max-width: vi.$fullhd !default;
 
   @include mx.until-widescreen {
     &.#{vi.$prefix}is-widescreen:not(.#{vi.$prefix}is-max-desktop) {
-      max-width: min($widescreen, $container-max-width) - $container-offset;
+      max-width: min(vi.$widescreen, $container-max-width) - $container-offset;
     }
   }
 
   @include mx.until-fullhd {
     &.#{vi.$prefix}is-fullhd:not(.#{vi.$prefix}is-max-desktop):not(.#{vi.$prefix}is-max-widescreen) {
-      max-width: min($fullhd, $container-max-width) - $container-offset;
+      max-width: min(vi.$fullhd, $container-max-width) - $container-offset;
     }
   }
 
   @include mx.widescreen {
     &:not(.#{vi.$prefix}is-max-desktop) {
-      max-width: min($widescreen, $container-max-width) - $container-offset;
+      max-width: min(vi.$widescreen, $container-max-width) - $container-offset;
     }
   }
 
   @include mx.fullhd {
     &:not(.#{vi.$prefix}is-max-desktop):not(.#{vi.$prefix}is-max-widescreen) {
-      max-width: min($fullhd, $container-max-width) - $container-offset;
+      max-width: min(vi.$fullhd, $container-max-width) - $container-offset;
     }
   }
 }


### PR DESCRIPTION
Replaced $widescreen and $fullhd with their namespace-prefixed counterparts (vi.$widescreen and vi.$fullhd) in the max-width calculation. This change ensures the proper variables are used from the namespace in the container layout styles.