### PR TITLE
Move autodark-image mixin to aside.scss

### DIFF
--- a/scss/layouts/aside.scss
+++ b/scss/layouts/aside.scss
@@ -10,8 +10,8 @@ $sidebar-h:                  vs.getVar("scheme-h");
 $sidebar-s:                  vs.getVar("scheme-s");
 $sidebar-l:                  vs.getVar("scheme-main-l");
 $sidebar-background-color:   vs.getVar("scheme-main-bis") !default;
-$sidebar-box-shadow-size:    0 0.125em 0 0 !default;
-$sidebar-box-shadow-color:   vs.getVar("gray") !default;
+$sidebar-box-shadow-size:    0 0 0.125em 0 !default;
+$sidebar-box-shadow-color:   vs.getVar("gray-light") !default;
 $sidebar-width:              vd.$sidebar-min-width !default;
 $sidebar-padding-vertical:   0 !default;
 $sidebar-padding-horizontal: 0 !default;
@@ -59,6 +59,7 @@ aside {
   align-items:      flex-start;
   overflow-y:       scroll;
   padding:          vs.getVar("sidebar-padding-vertical") vs.getVar("sidebar-padding-horizontal");
+  box-shadow:       vs.getVar("sidebar-box-shadow-size") vs.getVar("sidebar-box-shadow-color");
 
 
   @include mx.scrollbar;

--- a/scss/layouts/aside.scss
+++ b/scss/layouts/aside.scss
@@ -88,6 +88,10 @@ aside {
       img {
         height: 2rem;
         width:  auto;
+
+        @include vs.system-theme($name: "dark") {
+          @include mx.autodark-image;
+        }
       }
 
       @media (min-width: vi.$tablet) {
@@ -108,5 +112,17 @@ aside {
     .side {}
 
     .overlap {}
+  }
+}
+
+[data-theme="dark"] {
+  aside {
+    nav {
+      .brand {
+        img {
+          @include mx.autodark-image;
+        }
+      }
+    }
   }
 }

--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -6,13 +6,21 @@
 
 @mixin header-nav {}
 
-$header-h:                vs.getVar("scheme-h");
-$header-s:                vs.getVar("scheme-s");
-$header-l:                vs.getVar("scheme-main-l");
-$header-background-color: vs.getVar("scheme-main-ter") !default;
-$header-box-shadow-size:  0 0.125em 0 0 !default;
-$header-box-shadow-color: vs.getVar("gray") !default;
-$header-height:           vd.$header-min-height !default;
+$header-h:                  vs.getVar("scheme-h");
+$header-s:                  vs.getVar("scheme-s");
+$header-l:                  vs.getVar("scheme-main-l");
+$header-background-color:   vs.getVar("scheme-main-ter") !default;
+$header-box-shadow-size:    0 0.125em 0 0 !default;
+$header-box-shadow-color:   vs.getVar("gray") !default;
+$header-height:             vd.$header-min-height !default;
+$header-padding-vertical:   0 !default;
+$header-padding-horizontal: 0 !default;
+$header-z-index:            30 !default;
+$header-fixed-z-index:      30 !default;
+$header-brand-font-size:    vs.getVar("size-4") !default;
+$header-brand-font-weight:  700 !default;
+$header-brand-color:        vs.getVar("white-ter") !default;
+$header-brand-gap:          vi.$gap !default;
 
 :root {
   @include vs.register-vars((
@@ -27,7 +35,15 @@ header {
     "header-l": #{$header-l},
     "header-background-color": #{$header-background-color},
     "header-box-shadow-size": #{$header-box-shadow-size},
-    "header-box-shadow-color": #{$header-box-shadow-color}
+    "header-box-shadow-color": #{$header-box-shadow-color},
+    "header-z-index": #{$header-z-index},
+    "header-fixed-z-index": #{$header-fixed-z-index},
+    "header-padding-vertical": #{$header-padding-vertical},
+    "header-padding-horizontal": #{$header-padding-horizontal},
+    "header-brand-font-weight": #{$header-brand-font-weight},
+    "header-brand-font-size": #{$header-brand-font-size},
+    "header-brand-color": #{$header-brand-color},
+    "header-brand-gap": #{$header-brand-gap}
   ));
 }
 
@@ -35,17 +51,37 @@ header {
   background-color: vs.getVar("header-background-color");
   height:           vs.getVar("header-height");
   position:         fixed;
+  top:              0;
+  left:             0;
+  right:            0;
+  z-index:          vs.getVar("header-z-index");
+  align-items:      flex-start;
+  padding:          vs.getVar("header-padding-vertical") vs.getVar("header-padding-horizontal");
+  box-shadow:       vs.getVar("header-box-shadow-size") vs.getVar("header-box-shadow-color");
 
   @include mx.desktop {
     margin-left: vs.getVar("sidebar-width");
   }
 
   nav {
+    margin:  0;
+    padding: 0;
+
     .nav {}
 
     .expand {}
 
-    .brand {}
+    .brand {
+      display:     inline-flex;
+      align-items: center;
+      line-height: 1;
+      gap:         vs.getVar("header-brand-gap");
+      font-weight: vs.getVar("header-brand-font-weight");
+      font-size:   vs.getVar("header-brand-font-size");
+      color:       vs.getVar("header-brand-color");
+      margin:      0;
+      white-space: nowrap;
+    }
 
     .brand-image {}
 

--- a/scss/themes/dark.scss
+++ b/scss/themes/dark.scss
@@ -55,16 +55,4 @@ $text:          hsl(vi.$scheme-h, vi.$scheme-s, $text-l);
   ));
 
   @include vs.register-hsl("shadow", white);
-
-  [data-theme="dark"] {
-    aside {
-      nav {
-        .brand {
-          img {
-            @include mx.autodark-image;
-          }
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
The autodark-image mixin for the "dark" theme, previously in dark.scss, has been relocated to aside.scss. This aims to improve organization and maintainability by grouping related styles in the same file.