### PR TITLE
Add SCSS files for form styling

### DIFF
--- a/scss/configs/controls.scss
+++ b/scss/configs/controls.scss
@@ -1,3 +1,33 @@
 @use "variables-scss" as vs;
 @use "variables-derived" as vd;
 @use "variables-init" as vi;
+
+$control-radius:             vs.getVar("radius") !default;
+$control-radius-small:       vs.getVar("radius-small") !default;
+
+$control-border-width:       1px !default;
+$control-size:               vs.getVar("size-normal") !default;
+
+$control-height:             2.5em !default;
+$control-line-height:        1.5 !default;
+
+$control-padding-vertical:   calc(0.5em - #{$control-border-width}) !default;
+$control-padding-horizontal: calc(0.75em - #{$control-border-width}) !default;
+
+$control-focus-shadow-l:     50% !default
+
+:root {
+  @include vs.register-vars(
+    (
+      "control-radius": #{$control-radius},
+      "control-radius-small": #{$control-radius-small},
+      "control-border-width": #{$control-border-width},
+      "control-height": #{$control-height},
+      "control-line-height": #{$control-line-height},
+      "control-padding-vertical": #{$control-padding-vertical},
+      "control-padding-horizontal": #{$control-padding-horizontal},
+      "control-size": #{$control-size},
+      "control-focus-shadow-l": #{$control-focus-shadow-l},
+    )
+  );
+}

--- a/scss/configs/controls.scss
+++ b/scss/configs/controls.scss
@@ -69,3 +69,16 @@ $control-focus-shadow-l:     50% !default;
     cursor: not-allowed;
   }
 }
+
+@mixin control-small {
+  border-radius: $control-radius-small;
+  font-size:     vs.getVar("size-small");
+}
+
+@mixin control-medium {
+  font-size: vs.getVar("size-medium");
+}
+
+@mixin control-large {
+  font-size: vs.getVar("size-large");
+}

--- a/scss/configs/controls.scss
+++ b/scss/configs/controls.scss
@@ -18,16 +18,54 @@ $control-focus-shadow-l:     50% !default;
 
 :root {
   @include vs.register-vars(
-    (
-      "control-radius": #{$control-radius},
-      "control-radius-small": #{$control-radius-small},
-      "control-border-width": #{$control-border-width},
-      "control-height": #{$control-height},
-      "control-line-height": #{$control-line-height},
-      "control-padding-vertical": #{$control-padding-vertical},
-      "control-padding-horizontal": #{$control-padding-horizontal},
-      "control-size": #{$control-size},
-      "control-focus-shadow-l": #{$control-focus-shadow-l},
-    )
+      (
+        "control-radius": #{$control-radius},
+        "control-radius-small": #{$control-radius-small},
+        "control-border-width": #{$control-border-width},
+        "control-height": #{$control-height},
+        "control-line-height": #{$control-line-height},
+        "control-padding-vertical": #{$control-padding-vertical},
+        "control-padding-horizontal": #{$control-padding-horizontal},
+        "control-size": #{$control-size},
+        "control-focus-shadow-l": #{$control-focus-shadow-l},
+      )
   );
+}
+
+@mixin control {
+  align-items:         center;
+  appearance:          none;
+  border-color:        transparent;
+  border-style:        solid;
+  border-width:        vs.getVar("control-border-width");
+  border-radius:       vs.getVar("control-radius");
+  box-shadow:          none;
+  display:             inline-flex;
+  font-size:           vs.getVar("control-size");
+  height:              vs.getVar("control-height");
+  justify-content:     flex-start;
+  line-height:         vs.getVar("control-line-height");
+  padding-bottom:      vs.getVar("control-padding-vertical");
+  padding-left:        vs.getVar("control-padding-horizontal");
+  padding-right:       vs.getVar("control-padding-horizontal");
+  padding-top:         vs.getVar("control-padding-vertical");
+  position:            relative;
+  transition-duration: vs.getVar("duration");
+  transition-property: background-color, border-color, box-shadow, color;
+  vertical-align:      top;
+
+  // States
+  &:focus,
+  &:focus-visible,
+  &:focus-within,
+  &.#{vi.$prefix}is-focused,
+  &:active
+  &.#{vi.$prefix}is-active {
+    outline: none;
+  }
+
+  &[disabled],
+  fieldset[disabled] & {
+    cursor: not-allowed;
+  }
 }

--- a/scss/configs/controls.scss
+++ b/scss/configs/controls.scss
@@ -14,7 +14,7 @@ $control-line-height:        1.5 !default;
 $control-padding-vertical:   calc(0.5em - #{$control-border-width}) !default;
 $control-padding-horizontal: calc(0.75em - #{$control-border-width}) !default;
 
-$control-focus-shadow-l:     50% !default
+$control-focus-shadow-l:     50% !default;
 
 :root {
   @include vs.register-vars(

--- a/scss/configs/extends.scss
+++ b/scss/configs/extends.scss
@@ -1,5 +1,18 @@
+@use "controls";
 @use "mixins";
 
-%block{
+%arrow {
+  @include mixins.arrow;
+}
+
+%block {
   @include mixins.block;
+}
+
+%control {
+  @include controls.control;
+}
+
+%reset {
+  @include mixins.reset;
 }

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -94,6 +94,16 @@
   -webkit-overflow-scrolling: touch;
 }
 
+@mixin placeholder {
+  $placeholders: ":-moz" ":-webkit-input" "-moz" "-ms-input";
+
+  @each $placeholder in $placeholders {
+    &:#{$placeholder}-placeholder {
+      @content;
+    }
+  }
+}
+
 @mixin reset {
   appearance:  none;
   background:  none;

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -2,9 +2,35 @@
 @use "variables-scss" as vs;
 @use "variables-derived" as vd;
 
+@mixin arrow($color: #{vs.getVar("arrow-color")}) {
+  border:              0.125em solid $color;
+  border-right:        0;
+  border-top:          0;
+  content:             " ";
+  display:             block;
+  height:              0.625em;
+  margin-top:          -0.4375em;
+  pointer-events:      none;
+  position:            absolute;
+  top:                 50%;
+  transform:           rotate(-45deg);
+  transform-origin:    center;
+  transition-duration: vs.getVar("duration");
+  transition-property: border-color;
+  width:               0.625em;
+}
+
 @mixin block($spacing: vs.getVar("block-spacing")) {
   &:not(:last-child) {
     margin-bottom: $spacing;
+  }
+}
+
+@mixin clearfix {
+  &::after {
+    clear:   both;
+    content: " ";
+    display: table;
   }
 }
 
@@ -44,7 +70,7 @@
   #{if(&, "&", "*")}::-webkit-scrollbar-thumb {
     border-radius: 0.25rem;
     border:        0.125rem solid transparent;
-    box-shadow:    inset 0 0 0 0.25rem vs.getVar("scrollbar") ;
+    box-shadow:    inset 0 0 0 0.25rem vs.getVar("scrollbar");
   }
 
   #{if(&, "&", "*")}::-webkit-scrollbar-track {
@@ -52,7 +78,7 @@
   }
 
   #{if(&, "&", "*")}:hover::-webkit-scrollbar-thumb {
-    box-shadow: inset 0 0 0 0.25rem vs.getVar("scrollbar-hover") ;
+    box-shadow: inset 0 0 0 0.25rem vs.getVar("scrollbar-hover");
   }
 
   #{if(&, "&", "*")}::-webkit-scrollbar-corner {
@@ -62,14 +88,6 @@
 
 @mixin autodark-image {
   filter: brightness(0) invert(1);
-}
-
-@mixin clearfix {
-  &::after {
-    clear:   both;
-    content: " ";
-    display: table;
-  }
 }
 
 @mixin overflow-touch {

--- a/scss/forms/_index.scss
+++ b/scss/forms/_index.scss
@@ -1,0 +1,5 @@
+@charset "utf-8";
+
+/* Accouter Form */
+
+@forward "shared";

--- a/scss/forms/shared.scss
+++ b/scss/forms/shared.scss
@@ -1,0 +1,75 @@
+@use "../configs/variables-derived" as vd;
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$form-colors:                      vd.$colors !default;
+
+$input-h:                          #{vs.getVar("scheme-h")} !default;
+$input-s:                          #{vs.getVar("scheme-s")} !default;
+$input-l:                          #{vs.getVar("scheme-main-l")} !default;
+$input-border-l:                   vs.getVar("border-l") !default;
+$input-border-l-delta:             0% !default;
+$input-hover-border-l-delta:       #{vs.getVar("hover-border-l-delta")} !default;
+$input-active-border-l-delta:      #{vs.getVar("active-border-l-delta")} !default;
+$input-color-l:                    vs.getVar("text-strong-l") !default;
+$input-background-l:               vs.getVar("scheme-main-l") !default;
+$input-background-l-delta:         0% !default;
+$input-height:                     vs.getVar("control-height") !default;
+$input-shadow:                     inset 0 0.0625em 0.125em hsla(#{vs.getVar("scheme-h")}, #{vs.getVar("scheme-s")}, #{vs.getVar("scheme-invert-l")}, 0.05) !default;
+$input-placeholder-color:          hsla(#{vs.getVar("text-h")}, #{vs.getVar("text-s")}, #{vs.getVar("text-strong-l")}, 0.3) !default;
+
+$input-focus-h:                    vs.getVar("focus-h") !default;
+$input-focus-s:                    vs.getVar("focus-s") !default;
+$input-focus-l:                    vs.getVar("focus-l") !default;
+$input-focus-shadow-size:          vs.getVar("focus-shadow-size") !default;
+$input-focus-shadow-alpha:         vs.getVar("focus-shadow-alpha") !default;
+
+$input-disabled-color:             vs.getVar("text-weak") !default;
+$input-disabled-background-color:  vs.getVar("background") !default;
+$input-disabled-border-color:      vs.getVar("background") !default;
+$input-disabled-placeholder-color: hsla(#{vs.getVar("text-h")}, #{vs.getVar("text-s")}, #{vs.getVar("text-weak-l")}, 0.3) !default;
+
+$input-arrow:                      vs.getVar("link") !default;
+
+$input-icon-color:                 vs.getVar("text-light") !default;
+$input-icon-hover-color:           vs.getVar("text-weak") !default;
+$input-icon-focus-color:           vs.getVar("link") !default;
+
+$input-radius:                     vs.getVar("radius") !default;
+
+.#{vi.$prefix}control,
+.#{vi.$prefix}input,
+.#{vi.$prefix}textarea,
+.#{vi.$prefix}select {
+  @include vs.register-vars((
+    "input-h": #{$input-h},
+    "input-s": #{$input-s},
+    "input-l": #{$input-l},
+    "input-border-l": #{$input-border-l},
+    "input-border-l-delta": #{$input-border-l-delta},
+    "input-hover-border-l-delta": #{$input-hover-border-l-delta},
+    "input-active-border-l-delta": #{$input-active-border-l-delta},
+    "input-color-l": #{$input-color-l},
+    "input-background-l": #{$input-background-l},
+    "input-background-l-delta": #{$input-background-l-delta},
+    "input-height": #{$input-height},
+    "input-shadow": #{$input-shadow},
+    "input-placeholder-color": #{$input-placeholder-color},
+    "input-focus-h": #{$input-focus-h},
+    "input-focus-s": #{$input-focus-s},
+    "input-focus-l": #{$input-focus-l},
+    "input-focus-shadow-size": #{$input-focus-shadow-size},
+    "input-focus-shadow-alpha": #{$input-focus-shadow-alpha},
+    "input-disabled-color": #{$input-disabled-color},
+    "input-disabled-background-color": #{$input-disabled-background-color},
+    "input-disabled-border-color": #{$input-disabled-border-color},
+    "input-disabled-placeholder-color": #{$input-disabled-placeholder-color},
+    "input-arrow": #{$input-arrow},
+    "input-icon-color": #{$input-icon-color},
+    "input-icon-hover-color": #{$input-icon-hover-color},
+    "input-icon-focus-color": #{$input-icon-focus-color},
+    "input-radius": #{$input-radius}
+  ))
+}

--- a/scss/forms/shared.scss
+++ b/scss/forms/shared.scss
@@ -73,3 +73,7 @@ $input-radius:                     vs.getVar("radius") !default;
     "input-radius": #{$input-radius}
   ))
 }
+
+@mixin input {
+  @extend %control;
+}

--- a/scss/forms/shared.scss
+++ b/scss/forms/shared.scss
@@ -76,4 +76,48 @@ $input-radius:                     vs.getVar("radius") !default;
 
 @mixin input {
   @extend %control;
+  background-color: hsl(#{vs.getVar("input-h")}, #{vs.getVar("input-s")}, calc(#{vs.getVar("input-background-l")} + #{vs.getVar("input-background-l-delta")}));
+  border-color:     hsl(#{vs.getVar("input-h")}, #{vs.getVar("input-s")}, calc(#{vs.getVar("input-border-l")} + #{vs.getVar("input-border-l-delta")}));
+  border-radius:    vs.getVar("input-radius");
+  color:            hsl(#{vs.getVar("input-h")}, #{vs.getVar("input-s")}, #{vs.getVar("input-color-l")});
+
+  @include mx.placeholder {
+    color: vs.getVar("input-placeholder-color");
+  }
+
+  &:hover,
+  &.#{vi.$prefix}is-hovered {
+    @include vs.register-vars((
+      "input-border-l-delta": vs.getVar("input-hover-border-l-delta"),
+    ));
+  }
+  &:active,
+  &.#{vi.$prefix}is-active {
+    @include vs.register-vars((
+      "input-border-l-delta": vs.getVar("input-active-border-l-delta"),
+    ));
+  }
+
+  &:focus,
+  &:focus-within,
+  &.#{vi.$prefix}is-focused {
+    border-color: hsl(vs.getVar("input-focus-h"), vs.getVar("input-focus-s"), vs.getVar("input-focus-l"));
+    box-shadow:   vs.getVar("input-focus-shadow-size") hsla(vs.getVar("input-focus-h"), vs.getVar("input-focus-s"), vs.getVar("input-focus-l"), vs.getVar("input-focus-shadow-alpha"));
+  }
+
+  &[disabled],
+  fieldset[disabled] & {
+    background-color: vs.getVar("input-disabled-background-color");
+    border-color:     vs.getVar("input-disabled-border-color");
+    color:            vs.getVar("input-disabled-color");
+    box-shadow:       none;
+
+    @include mx.placeholder {
+      color: vs.getVar("input-disabled-placeholder-color");
+    }
+  }
+}
+
+%input {
+  @include input;
 }


### PR DESCRIPTION
Created `_index.scss` and `shared.scss` files under `scss/forms`. `_index.scss` does not contain much but forwards to shared styles. `shared.scss` sets up a multitude of variables relating to form styling, including colors, dimensions, and states such as hover, focus, and disable.