### PR TITLE
Add mixins placeholder helpers

### DIFF
--- a/scss/configs/extends.scss
+++ b/scss/configs/extends.scss
@@ -13,6 +13,18 @@
   @include controls.control;
 }
 
+%loader{
+  @include mixins.loader;
+}
+
+%overlay{
+  @include mixins.overlay;
+}
+
 %reset {
   @include mixins.reset;
+}
+
+%unselectable {
+  @include mixins.unselectable;
 }

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -257,3 +257,43 @@
     @content;
   }
 }
+
+// Placeholder
+
+@mixin unselectable {
+  -webkit-touch-callout: none;
+  -webkit-user-select:   none;
+  -moz-user-select:      none;
+  -ms-user-select:       none;
+  user-select:           none;
+}
+
+@mixin Loader {
+  animation:     spinAround 500ms infinite linear;
+  border:        2px solid vs.getVar("loading-color");
+  border-radius: vs.getVar("radius-rounded");
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -269,9 +269,16 @@
 }
 
 @mixin Loader {
-  animation:     spinAround 500ms infinite linear;
-  border:        2px solid vs.getVar("loading-color");
-  border-radius: vs.getVar("radius-rounded");
+  animation:          spinAround 500ms infinite linear;
+  border:             2px solid vs.getVar("loading-color");
+  border-radius:      vs.getVar("radius-rounded");
+  border-right-color: transparent;
+  border-top-color:   transparent;
+  content:            "";
+  display:            block;
+  height:             1em;
+  width:              1em;
+  position:           relative;
 }
 
 

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -46,6 +46,79 @@
   }
 }
 
+@mixin delete {
+  @include vs.register-vars((
+    "delete-dimensions": 1.25rem,
+    "delete-background-l": 0%,
+    "delete-background-alpha": 0.5,
+    "delete-color": vs.getVar("white"),
+  ));
+
+  appearance:       none;
+  cursor:           pointer;
+  pointer-events:   auto;
+  background-color: hsla(vs.getVar("scheme-h"), vs.getVar("scheme-s"), vs.getVar("delete-background-l"), vs.getVar("delete-background-alpha"));
+  border:           none;
+  outline:          none;
+  border-radius:    vs.getVar("radius-rounded");
+  display:          inline-flex;
+  position:         relative;
+  vertical-align:   top;
+  flex-grow:        0;
+  flex-shrink:      0;
+  font-size:        1em;
+  height:           vs.getVar("delete-dimensions");
+  max-width:        vs.getVar("delete-dimensions");
+  max-height:       vs.getVar("delete-dimensions");
+  min-height:       vs.getVar("delete-dimensions");
+  min-width:        vs.getVar("delete-dimensions");
+  width:            vs.getVar("delete-dimensions");
+
+  &::before,
+  &::after {
+    background-color: vs.getVar("delete-color");
+    content:          "";
+    display:          block;
+    position:         absolute;
+    left:             50%;
+    top:              50%;
+    transform:        translateX(-50%) translateY(-50%) rotate(45deg);
+    transform-origin: center center;
+  }
+
+  &::before{
+    height: 2px;
+    width:  50%;
+  }
+
+  &::after{
+    height: 50%;
+    width:  2px;
+  }
+
+  &::hover,
+  &::focus{
+    @include vs.register-var("delete-background-alpha", 0.4);
+  }
+
+  &:active{
+    @include vs.register-var("delete-background-alpha", 0.5);
+  }
+
+  // Sizes
+  &.#{vi.$prefix}is-small {
+    @include vs.register-var("delete-dimensions", 1rem);
+  }
+
+  &.#{vi.$prefix}is-medium {
+    @include vs.register-var("delete-dimensions", 1.5rem);
+  }
+
+  &.#{vi.$prefix}is-large {
+    @include vs.register-var("delete-dimensions", 2rem);
+  }
+}
+
 @mixin transition($transition...) {
   @if length($transition) == 0 {
     $transition: vd.$transition-base;

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -280,7 +280,7 @@
   user-select:           none;
 }
 
-@mixin Loader {
+@mixin loader {
   animation:          spinAround 500ms infinite linear;
   border:             2px solid vs.getVar("loading-color");
   border-radius:      vs.getVar("radius-rounded");

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -26,6 +26,18 @@
   }
 }
 
+@mixin center($width, $height: 0) {
+  position: absolute;
+
+  @if $height != 0 {
+    left: calc(50% - (#{$width} * 0.5));
+    top:  calc(50% - (#{$height} * 0.5));
+  } @else {
+    left: calc(50% - (#{$width} * 0.5));
+    top:  calc(50% - (#{$width} * 0.5));
+  }
+}
+
 @mixin clearfix {
   &::after {
     clear:   both;

--- a/scss/configs/mixins.scss
+++ b/scss/configs/mixins.scss
@@ -281,6 +281,14 @@
   position:           relative;
 }
 
+@mixin overlay($offset: 0) {
+  position: absolute;
+  bottom:   $offset;
+  left:     $offset;
+  right:    $offset;
+  top:      $offset;
+}
+
 
 
 


### PR DESCRIPTION
- This commit introduces two new mixins to the SCSS configuration: 'unselectable' and 'Loader'. The 'unselectable' mixin disables user selection while the 'Loader' mixin adds a continuous rotation effect to an element.

- The `Loader` mixin has been enhanced in the SCSS file. This includes the addition of attributes for border color, content, display, dimensions, and position. The changes aid in achieving better UI effects by allowing loading elements to have a more significant visual presence.

- This commit introduces a new mixin named 'overlay' to the SCSS configuration file. The overlay mixin has parameters for position attributes, all set to absolute, and allows an offset to be declared as a custom value.

- This commit updates the mixins.scss configuration file by adding a new mixin, 'center'. This mixin allows absolute positioning of centering elements either with specified width and height or with equal dimensions when height is not provided.

- Included loader, overlay, and unselectable mixins into the extends.scss configuration. Also made a correction to 'loader' mixin case in mixins.scss for consistency.

- introduces a new mixin named 'delete' in the SCSS configuration file. It includes a range of properties such as fonts, sizes, display, positioning, and colors. Sizes added include small, medium, and large. The commit also handled various states like hover, focus, and active.