### PR TITLE
Add states styles to button

### DIFF
--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -210,4 +210,12 @@ $no-palette:                               ("white", "black", "light", "dark");
       "button-outer-shadow-a": 0,
     ));
   }
+
+  &:focus-visible,
+  &.#{vi.$prefix}is-focused {
+    @include vs.register-var("button-border-width", 1px);
+
+    border-color: hsl(#{vs.getVar("focus-h")}, #{vs.getVar("focus-s")}, #{vs.getVar("focus-l")});
+    box-shadow:   vs.getVar("focus-shadow-size") hsla(#{vs.getVar("focus-h")}, #{vs.getVar("focus-s")}, #{vs.getVar("focus-l")}, #{vs.getVar("fovus-shadow-alpha")});
+  }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -201,4 +201,13 @@ $no-palette:                               ("white", "black", "light", "dark");
       "button-border-l-delta": calc(#{vs.getVar("button-hover-border-l-delta")}),
     ));
   }
+
+  &:active,
+  &.#{vi.$prefix}is-active {
+    @include vs.register-vars((
+      "button-background-l-delta": calc(#{vs.getVar("button-active-background-l-delta")}),
+      "button-border-l-delta": calc(#{vs.getVar("button-active-border-l-delta")}),
+      "button-outer-shadow-a": 0,
+    ));
+  }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -218,4 +218,12 @@ $no-palette:                               ("white", "black", "light", "dark");
     border-color: hsl(#{vs.getVar("focus-h")}, #{vs.getVar("focus-s")}, #{vs.getVar("focus-l")});
     box-shadow:   vs.getVar("focus-shadow-size") hsla(#{vs.getVar("focus-h")}, #{vs.getVar("focus-s")}, #{vs.getVar("focus-l")}, #{vs.getVar("fovus-shadow-alpha")});
   }
+
+  &[disabled],
+  fieldset[disabled] & {
+    background-color: vs.getVar("button-disabled-background-color");
+    border-color:     vs.getVar("button-disabled-border-color");
+    box-shadow:       vs.getVar("button-disabled-shadow");
+    opacity:          vs.getVar("button-disabled-opacity");
+  }
 }


### PR DESCRIPTION
This commit introduces additional CSS styles for the active state of buttons within the button.scss file. Now, when the button is in an active state or flagged as active, it will adapt styles for background colors and borders according to the corresponding theme or design variables. The outer shadow effect is also set to 0 to give the button a flat look upon activation.