### PR TITLE
Add style to buttons

### DIFF
--- a/scss/configs/functions.scss
+++ b/scss/configs/functions.scss
@@ -121,6 +121,27 @@
   @return $text-strong;
 }
 
+@function colorRgba($color, $alpha) {
+  @if type-of($color) != "color" {
+    @return $color;
+  }
+  @return rgba($color, $alpha);
+}
+
+@function colorDarken($color, $amount) {
+  @if type-of($color) != "color" {
+    @return $color;
+  }
+  @return darken($color, $amount);
+}
+
+@function colorLighten($color, $amount) {
+  @if type-of($color) != "color" {
+    @return $color;
+  }
+  @return lighten($color, $amount);
+}
+
 @function colorBrightness($name) {
   $color-brightness: round((red($name) * 299 + green($name) * 587 + blue($name) * 114) / 1000);
   $light-color: round((red(#fff) * 299 + green(#fff) * 587 + blue(#fff) * 114) / 1000);

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -296,9 +296,17 @@ $no-palette:                               ("white", "black", "light", "dark");
 
     &:hover {
       @include vs.register-vars((
-        "button-border-width": max(1px, 0.125em),
+        "button-border-width": max(2px, 0.125em),
         "button-outer-shadow-alpha": 1,
       ));
     }
+
+    &:active {
+      @include vs.register-vars((
+        "button-border-width": max(2px, 0.125em),
+        "button-outer-shadow-alpha": .8,
+      ));
+    }
+
   }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -331,9 +331,18 @@ $no-palette:                               ("white", "black", "light", "dark");
     &:active,
     &.#{vi.$prefix}is-active {
       background-color: fn.colorDarken($button-text-hover-background-color, 5%);
-      color: vs.getVar("button-active-color");
+      color:            vs.getVar("button-active-color");
+    }
+
+    &[disabled],
+    fieldset[disabled] & {
+      background-color: transparent;
+      border-color:     transparent;
+      box-shadow:       none;
     }
   }
 
-  &.#{vi.$prefix}is-ghost {}
+  &.#{vi.$prefix}is-ghost {
+
+  }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -5,6 +5,7 @@
 @use "../configs/variables-init" as vi;
 @use "../configs/extends";
 @use "../configs/mixins" as mx;
+@use "../configs/functions" as fn;
 
 $button-h:                                 #{vs.getVar("scheme-h")};
 $button-s:                                 #{vs.getVar("scheme-s")};
@@ -325,6 +326,12 @@ $no-palette:                               ("white", "black", "light", "dark");
     &.#{vi.$prefix}is-hovered {
       background-color: vs.getVar("button-text-hover-background-color");
       color:            vs.getVar("button-text-hover-color");
+    }
+
+    &:active,
+    &.#{vi.$prefix}is-active {
+      background-color: fn.colorDarken($button-text-hover-background-color, 5%);
+      color: vs.getVar("button-active-color");
     }
   }
 

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -343,6 +343,16 @@ $no-palette:                               ("white", "black", "light", "dark");
   }
 
   &.#{vi.$prefix}is-ghost {
+    background:      vs.getVar("button-ghost-background");
+    border-color:    vs.getVar("button-ghost-border-color");
+    color:           vs.getVar("button-ghost-color");
+    text-decoration: vs.getVar("button-ghost-decoration");
+    box-shadow:      none;
 
+    &:hover,
+    &.#{vi.$prefix}is-hovered {
+      color:           vs.getVar("button-ghost-hover-color");
+      text-decoration: vs.getVar("button-ghost-hover-decoration");
+    }
   }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -310,12 +310,23 @@ $no-palette:                               ("white", "black", "light", "dark");
 
   }
 
-  &.#{vi.$prefix}is-inverted{
+  &.#{vi.$prefix}is-inverted {
     background-color: hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, calc(#{vs.getVar("button-color-l")} + #{vs.getVar("button-background-l-delta")}));
     color:            hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, #{vs.getVar("button-background-l")});
   }
 
-  &.#{vi.$prefix}is-text{}
+  &.#{vi.$prefix}is-text {
+    background-color: transparent;
+    border-color:     transparent;
+    color:            vs.getVar("button-text-color");
+    text-decoration:  vs.getVar("button-text-decoration");
 
-  &.#{vi.$prefix}is-ghost{}
+    &:hover,
+    &.#{vi.$prefix}is-hovered {
+      background-color: vs.getVar("button-text-hover-background-color");
+      color:            vs.getVar("button-text-hover-color");
+    }
+  }
+
+  &.#{vi.$prefix}is-ghost {}
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -293,5 +293,12 @@ $no-palette:                               ("white", "black", "light", "dark");
     background-color: transparent;
     border-color:     hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, #{vs.getVar("button-l")});
     color:            hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, #{vs.getVar("button-l")});
+
+    &:hover {
+      @include vs.register-vars((
+        "button-border-width": max(1px, 0.125em),
+        "button-outer-shadow-alpha": 1,
+      ));
+    }
   }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -310,7 +310,10 @@ $no-palette:                               ("white", "black", "light", "dark");
 
   }
 
-  &.#{vi.$prefix}is-inverted{}
+  &.#{vi.$prefix}is-inverted{
+    background-color: hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, calc(#{vs.getVar("button-color-l")} + #{vs.getVar("button-background-l-delta")}));
+    color:            hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, #{vs.getVar("button-background-l")});
+  }
 
   &.#{vi.$prefix}is-text{}
 

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -309,4 +309,10 @@ $no-palette:                               ("white", "black", "light", "dark");
     }
 
   }
+
+  &.#{vi.$prefix}is-inverted{}
+
+  &.#{vi.$prefix}is-text{}
+
+  &.#{vi.$prefix}is-ghost{}
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -283,4 +283,15 @@ $no-palette:                               ("white", "black", "light", "dark");
       box-shadow:       none;
     }
   }
+
+  // styles
+  &.#{vi.$prefix}is-outlined {
+    @include vs.register-vars((
+      "button-border-width": max(1px, 0.0625em),
+    ));
+
+    background-color: transparent;
+    border-color:     hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, #{vs.getVar("button-l")});
+    color:            hsl(#{vs.getVar("button-h")}, #{vs.getVar("button-s")}, #{vs.getVar("button-l")});
+  }
 }


### PR DESCRIPTION
This commit introduces a new outlined style for buttons. The styles include a transparent background, hsl coloring, and a border width that adjusts based on the button's size. The new styles enhance visibility and aesthetic appeal.