### PR TITLE
Add size modifiers to button styles

### DIFF
--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -357,11 +357,31 @@ $no-palette:                               ("white", "black", "light", "dark");
   }
 
   // sizes
-  &.#{vi.$prefix}is-small {}
+  &.#{vi.$prefix}is-small {
+    @include vs.register-vars((
+      "control-size": #{vs.getVar("size-small")},
+      "control-radius": #{vs.getVar("radius-small")},
+    ));
+  }
 
-  &.#{vi.$prefix}is-normal {}
+  &.#{vi.$prefix}is-normal {
+    @include vs.register-vars((
+      "control-size": #{vs.getVar("size-normal")},
+      "control-radius": #{vs.getVar("radius")},
+    ));
+  }
 
-  &.#{vi.$prefix}is-medium {}
+  &.#{vi.$prefix}is-medium {
+    @include vs.register-vars((
+      "control-size": #{vs.getVar("size-medium")},
+      "control-radius": #{vs.getVar("radius-medium")},
+    ));
+  }
 
-  &.#{vi.$prefix}is-large {}
+  &.#{vi.$prefix}is-large {
+    @include vs.register-vars((
+      "control-size": #{vs.getVar("size-large")},
+      "control-radius": #{vs.getVar("radius-large")},
+    ));
+  }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -355,4 +355,13 @@ $no-palette:                               ("white", "black", "light", "dark");
       text-decoration: vs.getVar("button-ghost-hover-decoration");
     }
   }
+
+  // sizes
+  &.#{vi.$prefix}is-small {}
+
+  &.#{vi.$prefix}is-normal {}
+
+  &.#{vi.$prefix}is-medium {}
+
+  &.#{vi.$prefix}is-large {}
 }


### PR DESCRIPTION
Added empty rulesets for size modifiers including 'small', 'normal', 'medium', and 'large' to the button.scss file. The modifiers will allow for easy scalability in the style of buttons throughout the project.