### PR TITLE
Add button modifier to button styles

### DIFF
--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -391,9 +391,19 @@ $no-palette:                               ("white", "black", "light", "dark");
     width:   100%;
   }
 
-  &.#{vi.$prefix}is-loading{}
+  &.#{vi.$prefix}is-loading {
+    color:          transparent !important;
+    box-shadow:     none;
+    pointer-events: none;
 
-  &.#{vi.$prefix}is-static{}
+    &::after {
+      @extend %loader;
+      @include mx.center(1em);
+      position: absolute !important;
+    }
+  }
 
-  &.#{vi.$prefix}is-rounded{}
+  &.#{vi.$prefix}is-static {}
+
+  &.#{vi.$prefix}is-rounded {}
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -386,5 +386,14 @@ $no-palette:                               ("white", "black", "light", "dark");
   }
 
   // modifiers
-  &.#{vi.$prefix}is-fullwidth {}
+  &.#{vi.$prefix}is-fullwidth {
+    display: flex;
+    width:   100%;
+  }
+
+  &.#{vi.$prefix}is-loading{}
+
+  &.#{vi.$prefix}is-static{}
+
+  &.#{vi.$prefix}is-rounded{}
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -412,5 +412,9 @@ $no-palette:                               ("white", "black", "light", "dark");
     box-shadow:       none;
   }
 
-  &.#{vi.$prefix}is-rounded {}
+  &.#{vi.$prefix}is-rounded {
+    border-radius: vs.getVar("radius-rounded");
+    padding-left: calc(#{vs.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} - #{vs.getVar("button-border-width")});
+    padding-right: calc(#{vs.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} - #{vs.getVar("button-border-width")});
+  }
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -403,7 +403,14 @@ $no-palette:                               ("white", "black", "light", "dark");
     }
   }
 
-  &.#{vi.$prefix}is-static {}
+  &.#{vi.$prefix}is-static {
+
+    background-color: vs.getVar("button-static-background-color");
+    border-color:     vs.getVar("button-static-border-color");
+    color:            vs.getVar("button-static-color");
+    pointer-events:   none;
+    box-shadow:       none;
+  }
 
   &.#{vi.$prefix}is-rounded {}
 }

--- a/scss/elements/button.scss
+++ b/scss/elements/button.scss
@@ -384,4 +384,7 @@ $no-palette:                               ("white", "black", "light", "dark");
       "control-radius": #{vs.getVar("radius-large")},
     ));
   }
+
+  // modifiers
+  &.#{vi.$prefix}is-fullwidth {}
 }


### PR DESCRIPTION
The styles for the fullwidth button have been added to the button.scss file. This modifier will enable the usage of full-width buttons across the platform.