### PR TITLE
Add Azure Board Status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/accouter/accouter)](https://github.com/accouter/accouter/blob/main/LICENSE)
 [![Build status](https://dev.azure.com/wangkanai/Accouter/_apis/build/status/main-ci)](https://dev.azure.com/wangkanai/Accouter/_build/latest?definitionId=44)
 [![Github stars](https://img.shields.io/github/stars/accouter/accouter?style=social")](https://github.com/accouter/accouter)
-
+[![Board Status](https://dev.azure.com/wangkanai/4d05931f-8086-43cd-9525-fae9ffd6c9c0/e543d099-bab3-4b13-aff3-ccde0dc13ec9/_apis/work/boardbadge/91d630bf-108e-4a6f-849a-e473095480b7)](https://dev.azure.com/wangkanai/4d05931f-8086-43cd-9525-fae9ffd6c9c0/_boards/board/t/e543d099-bab3-4b13-aff3-ccde0dc13ec9/Epics/)
 
 <p align="center">
   <a href="https://github.com/sponsors/wangkanai">


### PR DESCRIPTION
This commit adds the Azure Board Status badge to the README.md file. Now, users can easily see the board status directly from the README, improving transparency and communication.