### PR TITLE
Add Element content with variables and definitions

### DIFF
--- a/scss/elements/_index.scss
+++ b/scss/elements/_index.scss
@@ -4,7 +4,7 @@
 @forward "block";
 @forward "box";
 @forward "button";
-//@forward "content";
+@forward "content";
 //@forward "delete";
 //@forward "icon";
 //@forward "image";

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -130,6 +130,28 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
 
   ol {
     list-style-position: outside;
+    margin-inline-start: 2em;
+    margin-top:          1em;
+
+    &:not([type]) {
+      list-style-type: decimal;
+
+      &.#{vi.$prefix}is-lower-alpha {
+        list-style-type: lower-alpha;
+      }
+
+      &.#{vi.$prefix}is-lower-roman {
+        list-style-type: lower-roman;
+      }
+
+      &.#{vi.$prefix}is-upper-alpha {
+        list-style-type: upper-alpha;
+      }
+
+      &.#{vi.$prefix}is-upper-roman {
+        list-style-type: upper-roman;
+      }
+    }
   }
 
   ul {}

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -1,0 +1,9 @@
+@use "../configs/variables-scss" as vs;
+@use "../configs/variables-derived" as vd;
+@use "../configs/variables-init" as vi;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$content-heading-color:       #{vs.getVar("text-strong")} !default;
+$content-heading-weight:      #{vs.getVar("weight-extrabold")} !default;
+$content-heading-line-height: 1.125 !default;

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -128,7 +128,9 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
     padding:          vs.getVar("content-blockquote-padding");
   }
 
-  ol {}
+  ol {
+    list-style-position: outside;
+  }
 
   ul {}
 

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -209,7 +209,50 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
     font-size: 75%;
   }
 
-  table {}
+  table {
+    td,
+    th {
+      border:         vs.getVar("content-table-cell-border");
+      border-width:   vs.getVar("content-table-cell-border-width");
+      padding:        vs.getVar("content-table-cell-padding");
+      vertical-align: top;
+    }
+
+    th {
+      color: vs.getVar("content-table-cell-heading-color");
+
+      &:not([align]) {
+        text-align: inherit;
+      }
+    }
+
+    thead {
+      td,
+      th {
+        border-width: vs.getVar("content-table-head-cell-border-width");
+        color:        vs.getVar("content-table-head-cell-color");
+      }
+    }
+
+    tfoot {
+      td,
+      th {
+        border-width: vs.getVar("content-table-foot-cell-border-width");
+        color:        vs.getVar("content-table-foot-cell-color");
+      }
+    }
+
+    tbody {
+      tr {
+        &:last-child {
+          td,
+          th {
+            border-bottom-width: vs.getVar("content-table-body-last-row-cell-border-bottom-width");
+          }
+        }
+      }
+    }
+  }
 
   .#{vi.$prefix}tabs {
     li + li {
@@ -218,11 +261,19 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
   }
 
   // sizes
-  &.#{vi.$prefix}is-small {}
+  &.#{vi.$prefix}is-small {
+    font-size: vs.getVar("size-small");
+  }
 
-  &.#{vi.$prefix}is-normal {}
+  &.#{vi.$prefix}is-normal {
+    font-size: vs.getVar("size-normal");
+  }
 
-  &.#{vi.$prefix}is-medium {}
+  &.#{vi.$prefix}is-medium {
+    font-size: vs.getVar("size-medium");
+  }
 
-  &.#{vi.$prefix}is-large {}
+  &.#{vi.$prefix}is-large {
+    font-size: vs.getVar("size-large");
+  }
 }

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -196,16 +196,26 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
     }
   }
 
-  pre {}
+  pre {
+    @include mx.overflow-touch;
+    overflow-x:  auto;
+    padding:     vs.getVar("content-pre-padding");
+    white-space: pre;
+    word-wrap:   normal;
+  }
 
   sup,
   sub {
-
+    font-size: 75%;
   }
 
   table {}
 
-  .#{vi.$prefix}tabs {}
+  .#{vi.$prefix}tabs {
+    li + li {
+      margin-top: 0;
+    }
+  }
 
   // sizes
   &.#{vi.$prefix}is-small {}

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -154,11 +154,47 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
     }
   }
 
-  ul {}
+  ul {
+    list-style:          disc outside;
+    margin-inline-start: 2em;
+    margin-top:          1em;
 
-  dd {}
+    ul {
+      list-style-type: circle;
+      margin-bottom:   0.25em;
+      margin-top:      0.25em;
 
-  figure:not([class]) {}
+      ul {
+        list-style-type: square;
+      }
+    }
+  }
+
+  dd {
+    margin-inline-start: 2em;
+  }
+
+  figure:not([class]) {
+    margin-left:  2em;
+    margin-right: 2em;
+    text-align:   center;
+
+    &:not(:first-child) {
+      margin-top: 1em;
+    }
+
+    &:not(:last-child) {
+      margin-bottom: 1em;
+    }
+
+    img {
+      display: inline-block;
+    }
+
+    figcaption {
+      font-style: italic;
+    }
+  }
 
   pre {}
 


### PR DESCRIPTION
This commit introduces the new content.scss file. Inside this file, we are importing configuration and mixin variables that will be used in this file. Also, the commit sets up three customizable SCSS variables for content headings, including color, weight, and line height.