### PR TITLE
Add styling to content class

### DIFF
--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -55,4 +55,62 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
   li + li {
     margin-top: 0.25em;
   }
+
+  // block
+  p,
+  dl,
+  ol,
+  ul,
+  blockquote,
+  pre,
+  table {}
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {}
+
+  h1 {}
+
+  h2 {}
+
+  h3 {}
+
+  h4 {}
+
+  h5 {}
+
+  h6 {}
+
+  blockquote {}
+
+  ol {}
+
+  ul {}
+
+  dd {}
+
+  figure:not([class]) {}
+
+  pre {}
+
+  sup,
+  sub {
+
+  }
+
+  table {}
+
+  .#{vi.$prefix}tabs {}
+
+  // sizes
+  &.#{vi.$prefix}is-small {}
+
+  &.#{vi.$prefix}is-normal {}
+
+  &.#{vi.$prefix}is-medium {}
+
+  &.#{vi.$prefix}is-large {}
 }

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -63,28 +63,70 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
   ul,
   blockquote,
   pre,
-  table {}
+  table {
+    &:not(:last-child) {
+      margin-bottom: vs.getVar("content-block-margin-bottom");
+    }
+  }
 
   h1,
   h2,
   h3,
   h4,
   h5,
-  h6 {}
+  h6 {
+    color:       vs.getVar("content-heading-color");
+    font-weight: vs.getVar("content-heading-weight");
+    line-height: vs.getVar("content-heading-line-height");
+  }
 
-  h1 {}
+  h1 {
+    font-size:     2em;
+    margin-bottom: 0.5em;
 
-  h2 {}
+    &:not(:first-child) {
+      margin-top: 1em;
+    }
+  }
 
-  h3 {}
+  h2 {
+    font-size:     1.75em;
+    margin-bottom: 0.5714em;
 
-  h4 {}
+    &:not(:first-child) {
+      margin-top: 1.1429em;
+    }
+  }
 
-  h5 {}
+  h3 {
+    font-size:     1.5em;
+    margin-bottom: 0.6667em;
 
-  h6 {}
+    &:not(:first-child) {
+      margin-top: 1.3333em;
+    }
+  }
 
-  blockquote {}
+  h4 {
+    font-size:     1.25em;
+    margin-bottom: 0.8em;
+  }
+
+  h5 {
+    font-size:     1.125em;
+    margin-bottom: 0.8888em;
+  }
+
+  h6 {
+    font-size:     1em;
+    margin-bottom: 1em;
+  }
+
+  blockquote {
+    background-color: vs.getVar("content-blockquote-background-color");
+    border-left:      vs.getVar("content-blockquote-border-left");
+    padding:          vs.getVar("content-blockquote-padding");
+  }
 
   ol {}
 

--- a/scss/elements/content.scss
+++ b/scss/elements/content.scss
@@ -47,3 +47,12 @@ $content-table-foot-cell-color:                        #{vs.getVar("text-strong"
     "content-table-foot-cell-color": #{$content-table-foot-cell-color},
   ));
 }
+
+.#{vi.$prefix}content {
+  @extend %block;
+
+  // inline
+  li + li {
+    margin-top: 0.25em;
+  }
+}


### PR DESCRIPTION
Added a top margin to consecutive list items within a content block in the content.scss file. This is to provide clearer separation between list items for better readability.