### PR TITLE
Add element image styling

### DIFF
--- a/scss/elements/image.scss
+++ b/scss/elements/image.scss
@@ -36,7 +36,7 @@ $dimensions: 16 24 32 48 64 96 128 256 512 !default;
     aspect-ratio: 1;
   }
 
-  @each $pair in vs.$aspect-ratios {
+  @each $pair in vi.$aspect-ratios {
     $w: nth($pair, 1);
     $h: nth($pair, 2);
 

--- a/scss/elements/image.scss
+++ b/scss/elements/image.scss
@@ -17,4 +17,46 @@ $dimensions: 16 24 32 48 64 96 128 256 512 !default;
       border-radius: vs.getVar("radius-rounded");
     }
   }
+
+  &.#{vi.$prefix}is-fullwidth {
+    width: 100%;
+  }
+
+  // ratio
+  &.#{vi.$prefix}is-square {
+    img,
+    .#{vi.$prefix}has-ratio {
+      @include mx.overlay;
+      height: 100%;
+      width:  100%;
+    }
+  }
+
+  &.#{vi.$prefix}is-square {
+    aspect-ratio: 1;
+  }
+
+  @each $pair in vs.$aspect-ratios {
+    $w: nth($pair, 1);
+    $h: nth($pair, 2);
+
+    &.#{vi.$prefix}is-#{$w}by#{$h} {
+      aspect-ratio: #{$w} / #{$h};
+
+      img,
+      .#{vi.$prefix}has-ratio {
+        @include mx.overlay;
+        height: 100%;
+        width:  100%;
+      }
+    }
+  }
+
+  // sizes
+  @each $dimension in $dimensions {
+    &.#{vi.$prefix}is-#{$dimension}x#{$dimension} {
+      height: $dimension * 1px;
+      width:  $dimension * 1px;
+    }
+  }
 }

--- a/scss/elements/image.scss
+++ b/scss/elements/image.scss
@@ -1,0 +1,20 @@
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/mixins" as mx;
+
+$dimensions: 16 24 32 48 64 96 128 256 512 !default;
+
+.#{vi.$prefix}image {
+  display:  block;
+  position: relative;
+
+  img {
+    display: block;
+    height:  auto;
+    width:   100%;
+
+    &.#{vi.$prefix}is-rounded {
+      border-radius: vs.getVar("radius-rounded");
+    }
+  }
+}


### PR DESCRIPTION
Modified the 'scss/elements/image.scss' file to include image styling rules. These rules provide basic layout and a rounded variation for images. They make use of SCSS variables and mixins, improving modularity and maintainability of the code.