### PR TITLE
Change default theme from dark to light

### DIFF
--- a/templates/accouter/layout/_master.tmpl
+++ b/templates/accouter/layout/_master.tmpl
@@ -3,7 +3,7 @@
 {{!include(favicon.ico)}}
 {{!include(logo.svg)}}
 <!DOCTYPE html>
-<html {{#_lang}}lang="{{_lang}}"{{/_lang}} data-theme="dark">
+<html {{#_lang}}lang="{{_lang}}"{{/_lang}} data-theme="light">
 <head>
   <meta charset="utf-8">
   {{#redirect_url}}
@@ -67,7 +67,7 @@
 </head>
 
 {{^redirect_url}}
-  <body class="" data-theme="dark" data-layout="{{_layout}}{{layout}}" data-yaml-mime="{{yamlmime}}">
+  <body class="" data-theme="light" data-layout="{{_layout}}{{layout}}" data-yaml-mime="{{yamlmime}}">
   <aside>
     {{^_disableSidebar}}
       <nav class="expand-xl" role="navigation">


### PR DESCRIPTION
The default theme has been changed from dark to light in the master layout template. This affects the HTML and body tag theme data attributes.