### PR TITLE
Add element titles and subtitles

### DIFF
--- a/scss/elements/title.scss
+++ b/scss/elements/title.scss
@@ -1,0 +1,46 @@
+@use "../configs/variables-scss" as vs;
+@use "../configs/variables-derived" as vd;
+@use "../configs/variables-init" as vi;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$title-color:            vs.getVar("text-strong") !default;
+$title-family:           false !default;
+$title-size:             vs.getVar("size-3") !default;
+$title-weight:           vs.getVar("weight-extrabold") !default;
+$title-line-height:      1.125 !default;
+$title-strong-color:     inherit !default;
+$title-strong-weight:    inherit !default;
+$title-sub-size:         0.75em !default;
+$title-sup-size:         0.75em !default;
+
+$subtitle-color:         vs.getVar("text") !default;
+$subtitle-family:        false !default;
+$subtitle-size:          vs.getVar("size-5") !default;
+$subtitle-weight:        vs.getVar("weight-normal") !default;
+$subtitle-line-height:   1.25 !default;
+$subtitle-strong-color:  vs.getVar("text-strong") !default;
+$subtitle-strong-weight: vs.getVar("weight-semibold") !default;
+
+.#{vi.$prefix}title,
+.#{vi.$prefix}subtitle {
+  @include vs.register-vars((
+    "title-color": #{$title-color},
+    "title-family": #{$title-family},
+    "title-size": #{$title-size},
+    "title-weight": #{$title-weight},
+    "title-line-height": #{$title-line-height},
+    "title-strong-color": #{$title-strong-color},
+    "title-strong-weight": #{$title-strong-weight},
+    "title-sub-size": #{$title-sub-size},
+    "title-sup-size": #{$title-sup-size},
+    "subtitle-color": #{$subtitle-color},
+    "subtitle-family": #{$subtitle-family},
+    "subtitle-size": #{$subtitle-size},
+    "subtitle-weight": #{$subtitle-weight},
+    "subtitle-line-height": #{$subtitle-line-height},
+    "subtitle-strong-color": #{$subtitle-strong-color},
+    "subtitle-strong-weight": #{$subtitle-strong-weight},
+  ));
+}
+

--- a/scss/elements/title.scss
+++ b/scss/elements/title.scss
@@ -45,12 +45,56 @@ $subtitle-strong-weight: vs.getVar("weight-semibold") !default;
 }
 
 .#{vi.$prefix}title,
-.#{vi.$prefix}subtitle {}
+.#{vi.$prefix}subtitle {
+  @extend %block;
+  word-break: break-word;
 
-.#{vi.$prefix}title,
-.#{vi.$prefix}subtitle {}
+  em,
+  span {
+    font-weight: inherit;
+  }
 
-.#{vi.$prefix}title {}
+  sub {
+    font-size: vs.getVar("title-sub-size");
+  }
+
+  sup {
+    font-size: vs.getVar("title-sup-size");
+  }
+
+  .#{vi.$prefix}tag {
+    vertical-align: middle;
+  }
+}
+
+.#{vi.$prefix}title {
+  color:       vs.getVar("title-color");
+  font-size:   vs.getVar("title-size");
+  font-weight: vs.getVar("title-weight");
+  line-height: vs.getVar("title-line-height");
+
+  @if $title-family {
+    font-family: vs.getVar("title-family");
+  }
+
+  strong {
+    color:       vs.getVar("title-strong-color");
+    font-weight: vs.getVar("title-strong-weight");
+  }
+
+  &:not(#{vi.$prefix}is-spaced):has(* .#{vi.$prefix}subtitle) {
+    margin-bottom: 0;
+  }
+
+  // sizes
+  @each $size in vd.$sizes {
+    $i: index(vd.$sizes, $size);
+
+    &.#{vi.$prefix}is-#{$i} {
+      font-size: $size;
+    }
+  }
+}
 
 .#{vi.$prefix}subtitle {
   color:       vs.getVar("subtitle-color");

--- a/scss/elements/title.scss
+++ b/scss/elements/title.scss
@@ -44,3 +44,39 @@ $subtitle-strong-weight: vs.getVar("weight-semibold") !default;
   ));
 }
 
+.#{vi.$prefix}title,
+.#{vi.$prefix}subtitle {}
+
+.#{vi.$prefix}title,
+.#{vi.$prefix}subtitle {}
+
+.#{vi.$prefix}title {}
+
+.#{vi.$prefix}subtitle {
+  color:       vs.getVar("subtitle-color");
+  font-size:   vs.getVar("subtitle-size");
+  font-weight: vs.getVar("subtitle-weight");
+  line-height: vs.getVar("subtitle-line-height");
+
+  @if $subtitle-family {
+    font-family: vs.getVar("subtitle-family");
+  }
+
+  strong {
+    color:       vs.getVar("subtitle-strong-color");
+    font-weight: vs.getVar("subtitle-strong-weight");
+  }
+
+  &:not(.#{vi.$prefix}is-spaced):has(* .#{vi.$prefix}title) {
+    margin-bottom: 0;
+  }
+
+  // sizes
+  @each $size in vd.$sizes {
+    $i: index(vd.$sizes, $size);
+
+    &.#{vi.$prefix}is-#{$i} {
+      font-size: $size;
+    }
+  }
+}


### PR DESCRIPTION
Implemented SCSS customization for title and subtitle components in title.scss file. Added variables for style elements such as color, size, font-weight and line-height for more effective style management. Also included extends and mixins for efficient code reuse.