### PR TITLE
Add element form components

### DIFF
--- a/scss/forms/_index.scss
+++ b/scss/forms/_index.scss
@@ -1,5 +1,9 @@
 @charset "utf-8";
 
 /* Accouter Form */
-
 @forward "shared";
+@forward "input-textarea";
+@forward "checkbox-radio";
+@forward "select";
+@forward "file";
+@forward "tools";

--- a/scss/forms/checkbox-radio.scss
+++ b/scss/forms/checkbox-radio.scss
@@ -1,0 +1,32 @@
+@use "shared";
+@use "../configs/variables-init" as vi;
+
+%checkbox-radio {
+  display:     inline-block;
+  position:    relative;
+  cursor:      pointer;
+  line-height: 1.25;
+
+  input {
+    cursor: pointer;
+  }
+
+  &[disabled],
+  fieldset[disabled] &,
+  input[disabled] {
+    cursor: not-allowed;
+    color:  shared.$input-disabled-color;
+  }
+}
+
+.#{vi.$prefix}checkbox {
+  @extend %checkbox-radio;
+}
+
+.#{vi.$prefix}radio {
+  @extend %checkbox-radio;
+
+  & + .#{vi.$prefix}radio {
+    margin-inline-start: 0.5em;
+  }
+}

--- a/scss/forms/file.scss
+++ b/scss/forms/file.scss
@@ -1,0 +1,299 @@
+@use "shared";
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/extends";
+@use "../configs/controls";
+
+$file-radius:                    vs.getVar("radius") !default;
+
+$file-h:                         vs.getVar("scheme-h");
+$file-s:                         vs.getVar("scheme-s");
+$file-background-l:              vs.getVar("scheme-main-ter-l");
+$file-background-l-delta:        0%;
+$file-hover-background-l-delta:  -5%;
+$file-active-background-l-delta: -10%;
+$file-border-l:                  vs.getVar("border-l");
+$file-border-l-delta:            0%;
+$file-hover-border-l-delta:      -10%;
+$file-active-border-l-delta:     -20%;
+$file-cta-color-l:               vs.getVar("text-strong-l");
+$file-name-color-l:              vs.getVar("text-strong-l");
+$file-color-l-delta:             0%;
+$file-hover-color-l-delta:       -5%;
+$file-active-color-l-delta:      -10%;
+
+$file-cta-color:                 vs.getVar("text") !default;
+$file-cta-hover-color:           vs.getVar("text-strong") !default;
+$file-cta-active-color:          vs.getVar("text-strong") !default;
+
+$file-name-border-color:         vs.getVar("border") !default;
+$file-name-border-style:         solid !default;
+$file-name-border-width:         1px 1px 1px 0 !default;
+$file-name-max-width:            16em !default;
+
+$file-colors:                    shared.$form-colors !default;
+
+.#{vi.$prefix}file {
+  @extend %block;
+  @extend %unselectable;
+
+  @include vs.register-vars((
+    "file-radius": #{$file-radius},
+    "file-name-border-color": #{$file-name-border-color},
+    "file-name-border-style": #{$file-name-border-style},
+    "file-name-border-width": #{$file-name-border-width},
+    "file-name-max-width": #{$file-name-max-width},
+    "file-h": #{$file-h},
+    "file-s": #{$file-s},
+    "file-background-l": #{$file-background-l},
+    "file-background-l-delta": #{$file-background-l-delta},
+    "file-hover-background-l-delta": #{$file-hover-background-l-delta},
+    "file-active-background-l-delta": #{$file-active-background-l-delta},
+    "file-border-l": #{$file-border-l},
+    "file-border-l-delta": #{$file-border-l-delta},
+    "file-hover-border-l-delta": #{$file-hover-border-l-delta},
+    "file-active-border-l-delta": #{$file-active-border-l-delta},
+    "file-cta-color-l": #{$file-cta-color-l},
+    "file-name-color-l": #{$file-name-color-l},
+    "file-color-l-delta": #{$file-color-l-delta},
+    "file-hover-color-l-delta": #{$file-hover-color-l-delta},
+    "file-active-color-l-delta": #{$file-active-color-l-delta},
+  ));
+
+  display:         flex;
+  position:        relative;
+  justify-content: flex-start;
+  align-items:     stretch;
+
+  // colors
+  @each $name, $pair in $file-colors {
+    &.#{vi.$prefix}is-#{$name} {
+      @include vs.register-vars((
+        "file-h": vs.getVar($name, "", "-h"),
+        "file-s": vs.getVar($name, "", "-s"),
+        "file-background-l": vs.getVar($name, "", "-l"),
+        "file-border-l": vs.getVar($name, "", "-l"),
+        "file-cta-color-l": vs.getVar($name, "", "-l"),
+        "file-name-color-l": vs.getVar($name, "", "-l"),
+      ));
+    }
+  }
+
+  // sizes
+  &.#{vi.$prefix}is-small {
+    font-size: vs.getVar("size-small");
+  }
+
+  &.#{vi.$prefix}is-normal {
+    font-size: vs.getVar("size-normal");
+  }
+
+  &.#{vi.$prefix}is-medium {
+    font-size: vs.getVar("size-medium");
+
+    .#{vi.$prefix}file-icon {
+      .#{vi.$prefix}fa {
+        font-size: 1.5rem;
+      }
+    }
+  }
+
+  &.#{vi.$prefix}is-large {
+    font-size: vs.getVar("size-large");
+
+    .#{vi.$prefix}file-icon {
+      .#{vi.$prefix}fa {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  // modifiers
+  &.#{vi.$prefix}has-name {
+    &.#{vi.$prefix}file-cta {
+      border-end-end-radius:   0;
+      border-start-end-radius: 0;
+    }
+
+    &.#{vi.$prefix}file-name {
+      border-end-start-radius:   0;
+      border-start-start-radius: 0;
+    }
+
+    &.#{vi.$prefix}is-empty {
+      .#{vi.$prefix}file-cta {
+        border-radius: vs.getVar("file-radius");
+      }
+
+      .#{vi.$prefix}file-name {
+        display: none;
+      }
+    }
+  }
+
+  &.#{vi.$prefix}is-boxed {
+    .#{vi.$prefix}file-label {
+      flex-direction: column;
+    }
+
+    .#{vi.$prefix}file-cta {
+      flex-direction: column;
+      height:         auto;
+      padding:        1em 3em;
+    }
+
+    .#{vi.$prefix}file-name {
+      border-width: 0 1px 1px;
+    }
+
+    .#{vi.$prefix}file-icon {
+      height: 1.5em;
+      width:  1.5em;
+
+      .#{vi.$prefix}fa {
+        font-size: 1.5rem;
+      }
+    }
+
+    &.#{vi.$prefix}is-small {
+      .#{vi.$prefix}file-icon .#{vi.$prefix}fa {
+        font-size: 1rem;
+      }
+    }
+
+    &.#{vi.$prefix}is-medium {
+      .#{vi.$prefix}file-icon .#{vi.$prefix}fa {
+        font-size: 2rem;
+      }
+    }
+
+    &.#{vi.$prefix}is-large {
+      .#{vi.$prefix}file-icon .#{vi.$prefix}fa {
+        font-size: 2.5rem;
+      }
+    }
+
+    &.#{vi.$prefix}has-name {
+      .#{vi.$prefix}file-cta {
+        border-end-end-radius:     0;
+        border-end-start-radius:   0;
+        border-start-end-radius:   vs.getVar("file-radius");
+        border-start-start-radius: vs.getVar("file-radius");
+      }
+
+      .#{vi.$prefix}file-name {
+        border-end-end-radius:     vs.getVar("file-radius");
+        border-end-start-radius:   vs.getVar("file-radius");
+        border-start-end-radius:   0;
+        border-start-start-radius: 0;
+        border-width:              0 1px 1px;
+      }
+    }
+  }
+
+  &.#{vi.$prefix}is-centered {
+    justify-content: center;
+  }
+
+  &.#{vi.$prefix}is-fullwidth {
+    .#{vi.$prefix}file-label {
+      width: 100%;
+    }
+
+    .#{vi.$prefix}file-name {
+      max-width: none;
+      flex-grow: 1;
+    }
+  }
+
+  &.#{vi.$prefix}is-right {
+    justify-content: flex-end;
+
+    .#{vi.$prefix}file-cta {
+      border-radius: 0 vs.getVar("file-radius") vs.getVar("file-radius") 0;
+    }
+
+    .#{vi.$prefix}file-name {
+      border-radius: vs.getVar("file-radius") 0 0 vs.getVar("file-radius");
+      border-width:  1px 0 1px 1px;
+      order:         -1;
+    }
+  }
+}
+
+.#{vi.$prefix}file-label {
+  display:         flex;
+  position:        relative;
+  align-items:     stretch;
+  justify-content: flex-start;
+  overflow:        hidden;
+  cursor:          pointer;
+
+  &:hover {
+    @include vs.register-vars((
+      "file-background-l-delta": #{vs.getVar("file-hover-background-l-delta")},
+      "file-border-l-delta": #{vs.getVar("file-hover-border-l-delta")},
+      "file-color-l-delta": #{vs.getVar("file-hover-color-l-delta")},
+    ));
+  }
+
+  &:active {
+    @include vs.register-vars((
+      "file-background-l-delta": #{vs.getVar("file-active-background-l-delta")},
+      "file-border-l-delta": #{vs.getVar("file-active-border-l-delta")},
+      "file-color-l-delta": #{vs.getVar("file-active-color-l-delta")},
+    ));
+  }
+}
+
+.#{vi.$prefix}file-input {
+  position: absolute;
+  height:   100%;
+  width:    100%;
+  top:      0;
+  left:     0;
+  opacity:  0;
+  outline:  none;
+}
+
+.#{vi.$prefix}file-cta,
+.#{vi.$prefix}file-name {
+  @extend %control;
+
+  border-color:  hsl(vs.getVar("file-h"), vs.getVar("file-s"), calc(#{vs.getVar("file-border-l")} + #{vs.getVar("file-border-l-delta")}));
+  border-radius: vs.getVar("file-radius");
+  white-space:   nowrap;
+  font-size:     1em;
+  padding-left:  1em;
+  padding-right: 1em;
+}
+
+.#{vi.$prefix}file-cta {
+  background-color: hsl(vs.getVar("file-h"), vs.getVar("file-s"), calc(#{vs.getVar("file-background-l")} + #{vs.getVar("file-background-l-delta")}));
+  color:            hsl(vs.getVar("file-h"), vs.getVar("file-s"), calc(#{vs.getVar("file-cta-color-l")} + #{vs.getVar("file-color-l-delta")}));
+}
+
+.#{vi.$prefix}file-name {
+  display:       block;
+  max-width:     vs.getVar("file-name-max-width");
+  overflow:      hidden;
+  text-align:    inherit;
+  text-overflow: ellipsis;
+  border-color:  hsl(vs.getVar("file-h"), vs.getVar("file-s"), calc(#{vs.getVar("file-border-l")} + #{vs.getVar("file-color-l-delta")}));
+  border-style:  vs.getVar("file-name-border-style");
+  border-width:  vs.getVar("file-name-border-width");
+  color:         hsl(vs.getVar("file-h"), vs.getVar("file-s"), calc(#{vs.getVar("file-name-color-l")} + #{vs.getVar("file-color-l-delta")}));
+}
+
+.#{vi.$prefix}file-icon {
+  display:           flex;
+  align-items:       center;
+  justify-content:   center;
+  height:            1em;
+  width:             1em;
+  margin-inline-end: 0.5em;
+
+  .#{vi.$prefix}fa {
+    font-size: 1em;
+  }
+}

--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -1,0 +1,122 @@
+@use "shared";
+@use "../configs/variables-derived" as vd;
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/extends";
+@use "../configs/controls";
+@use "../configs/mixins" as mx;
+
+$textarea-padding:    vs.getVar("control-padding-horizontal") !default;
+$textarea-max-height: 40em !default;
+$textarea-min-height: 8em !default;
+
+$textarea-colors:     vd.$colors !default;
+
+%input-textarea {
+  @extend %input;
+
+  @include vs.regiser-vars((
+    "input-h": vs.getVar("scheme-h"),
+    "input-s": vs.getVar("scheme-s"),
+    "input-border-style": solid,
+    "input-border-width": 1px,
+    "input-border-l": vs.getVar("border-l")
+  ));
+
+  box-shadow: shared.$input-shadow;
+  max-width:  100%;
+  width:      100%;
+
+  &[readonly] {
+    box-shadow: none;
+  }
+
+  // colors
+  @each $name, $pair in $textarea-colors {
+    $color: nth($pair, 1);
+
+    &.#{vi.$prefix}is-#{$name} {
+      @include vs.register-vars((
+        "input-h": vs.getVar($name, "", "-h"),
+        "input-s": vs.getVar($name, "", "-s"),
+        "input-l": vs.getVar($name, "", "-l"),
+        "input-focus-h": vs.getVar($name, "", "-h"),
+        "input-focus-s": vs.getVar($name, "", "-s"),
+        "input-focus-l": vs.getVar($name, "", "-l"),
+        "input-border-l": vs.getVar($name, "", "-l")
+      ));
+    }
+  }
+
+  // sizes
+  &.#{vi.$prefix}is-small {
+    @include controls.control-small;
+  }
+
+  &.#{vi.$prefix}is-medium {
+    @include controls.control-medium;
+  }
+
+  &.#{vi.$prefix}is-large {
+    @include controls.control-large;
+  }
+
+  // modifiers
+  &.#{vi.$prefix}is-fullwidth {
+    display: block;
+    width:   100%;
+  }
+
+  &.#{vi.$prefix}is-inline {
+    display: inline;
+    width:   auto;
+  }
+}
+
+.#{vi.$prefix}input {
+  @extend %input-textarea;
+
+  &.#{vi.$prefix}is-static {
+    border-color:     transparent;
+    background-color: transparent;
+    box-shadow:       none;
+    padding-left:     0;
+    padding-right:    0;
+  }
+
+  &.#{vi.$prefix}is-rounded {
+    border-radius: vs.getVar("radius-rounded");
+    padding-left:  calc(#{controls.$control-padding-horizontal} + 0.375em);
+    padding-right: calc(#{controls.$control-padding-horizontal} + 0.375em);
+  }
+}
+
+.#{vi.$prefix}textarea {
+  @extend %input-textarea;
+
+  @include vs.register-vars((
+    "textarea-padding": #{$textarea-padding},
+    "textarea-max-height": #{$textarea-max-height},
+    "textarea-min-height": #{$textarea-min-height}
+  ));
+
+  display:   block;
+  max-width: 100%;
+  min-width: 100%;
+  resize:    vertical;
+  padding:   vs.getVar("textarea-padding");
+
+  &:not([rows]) {
+    max-height: vs.getVar("textarea-max-height");
+    min-height: vs.getVar("textarea-min-height");
+  }
+
+  &[rows] {
+    height: inherit;
+  }
+
+  // modifiers
+  &.#{vi.$prefix}has-fixed-size {
+    resize: none;
+  }
+}

--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -15,7 +15,7 @@ $textarea-colors:     vd.$colors !default;
 %input-textarea {
   @extend %input;
 
-  @include vs.regiser-vars((
+  @include vs.register-vars((
     "input-h": vs.getVar("scheme-h"),
     "input-s": vs.getVar("scheme-s"),
     "input-border-style": solid,

--- a/scss/forms/select.scss
+++ b/scss/forms/select.scss
@@ -1,0 +1,142 @@
+@use "shared";
+@use "../configs/variables-derived" as vd;
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/controls";
+@use "../configs/extends";
+
+$select-colors: shared.$form-colors !default;
+
+.#{vi.$prefix}select {
+  @include vs.register-vars((
+    "input-h": #{vs.getVar("scheme-h")},
+    "input-s": #{vs.getVar("scheme-s")},
+    "input-border-style": solid,
+    "input-border-width": 1px,
+    "input-border-l": #{vs.getVar("border-l")},
+  ));
+
+  display:        inline-block;
+  position:       relative;
+  max-width:      100%;
+  vertical-align: top;
+
+  &:not(.#{vi.$prefix}is-multiple) {
+    height: shared.$input-height;
+  }
+
+  &:not(.#{vi.$prefix}is-multiple):not(.#{vi.$prefix}is-loading) {
+    &::after {
+      @extend %arrow;
+      inset-inline-end: 1.125em;
+      z-index:          4;
+    }
+  }
+
+  &.#{vi.$prefix}is-rounded {
+    select {
+      border-radius:        vs.getVar("radius-rounded");
+      padding-inline-start: 1em;
+    }
+  }
+
+  select {
+    @extend %input;
+
+    display:   block;
+    max-width: 100%;
+    font-size: 1em;
+    cursor:    pointer;
+    outline:   none;
+
+    &::-ms-expand {
+      display: none;
+    }
+
+    &[disabled]:hover,
+    fieldset[disabled] &:hover {
+      border-color: shared.$input-disabled-border-color;
+    }
+
+    &:not([multiple]) {
+      padding-inline-end: 2.5em;
+    }
+
+    &[multiple] {
+      height:  auto;
+      padding: 0;
+
+      option {
+        padding: 0.5em 1em;
+      }
+    }
+  }
+
+  // colors
+  @each $name, $pair in $select-colors {
+    &.#{vi.$prefix}is-#{$name} {
+      @include vs.register-vars((
+        "input-h": #{vs.getVar($name, "", "-h")},
+        "input-s": #{vs.getVar($name, "", "-s")},
+        "input-l": #{vs.getVar($name, "", "-l")},
+        "input-focus-h": #{vs.getVar($name, "", "-h")},
+        "input-focus-s": #{vs.getVar($name, "", "-s")},
+        "input-focus-l": #{vs.getVar($name, "", "-l")},
+        "arrow-color": #{vs.getVar($name)},
+      ));
+    }
+  }
+
+  // sizes
+  &.#{vi.$prefix}is-small {
+    @include controls.control-small;
+  }
+
+  &.#{vi.$prefix}is-medium {
+    @include controls.control-medium;
+  }
+
+  &.#{vi.$prefix}is-large {
+    @include controls.control-large;
+  }
+
+  // modifiers
+  &.#{vi.$prefix}is-disabled {
+    &::after {
+      border-color: shared.$input-disabled-color !important;
+      opacity:      0.5;
+    }
+  }
+
+  &.#{vi.$prefix}is-fullwidth {
+    width: 100%;
+
+    select {
+      width: 100%;
+    }
+  }
+
+  &.#{vi.$prefix}is-loading {
+    &::after {
+      @extend %loader;
+
+      position:         absolute;
+      top:              0.625em;
+      margin-top:       0;
+      transform:        none;
+      inset-inline-end: 0.625em;
+    }
+
+    &.#{vi.$prefix}is-small:after {
+      font-size: vs.getVar("size-small");
+    }
+
+    &.#{vi.$prefix}is-medium:after {
+      font-size: vs.getVar("size-medium");
+    }
+
+    &.#{vi.$prefix}is-large:after {
+      font-size: vs.getVar("size-large");
+    }
+  }
+}

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -1,0 +1,325 @@
+@use "shared";
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$label-color:  vs.getVar("text-strong") !default;
+$label-weight: vs.getVar("weight-semibold") !default;
+
+$help-size:    vs.getVar("size-small") !default;
+
+$label-colors: shared.$form-colors !default;
+
+.#{vi.$prefix}label {
+  display:     block;
+  color:       $label-color;
+  font-size:   vs.getVar("size-normal");
+  font-weight: $label-weight;
+
+  &:not(:last-child) {
+    margin-bottom: 0.5em;
+  }
+
+  // sizes
+  &.#{vi.$prefix}is-small {
+    font-size: vs.getVar("size-small");
+  }
+
+  &.#{vi.$prefix}is-medium {
+    font-size: vs.getVar("size-medium");
+  }
+
+  &.#{vi.$prefix}is-large {
+    font-size: vs.getVar("size-large");
+  }
+}
+
+.#{vi.$prefix}help {
+  display:    block;
+  margin-top: 0.25rem;
+  font-size:  $help-size;
+
+  @each $name, $pair in $label-colors {
+    &.#{vi.$prefix}is-#{$name} {
+      color: hsl(#{vs.getVar($name, "", "-h")}, #{vs.getVar($name, "", "-s")}, #{vs.getVar($name, "", "-on-scheme-l")});
+    }
+  }
+}
+
+// containers
+
+.#{vi.$prefix}field {
+  @include vs.register-vars((
+    "block-spacing": 0.75rem,
+  ));
+
+  @extend %block;
+
+  // modifiers
+  &.#{vi.$prefix}has-addons {
+    display:         flex;
+    justify-content: flex-start;
+
+    .#{vi.$prefix}control {
+      &:not(:last-child) {
+        margin-inline-end: -1px;
+      }
+
+      &:not(:first-child):not(:last-child) {
+        .#{vi.$prefix}button,
+        .#{vi.$prefix}input,
+        .#{vi.$prefix}select select {
+          border-radius: 0;
+        }
+      }
+
+      &:first-child:not(:only-child) {
+        .#{vi.$prefix}button,
+        .#{vi.$prefix}input,
+        .#{vi.$prefix}select select {
+          border-top-left-radius:    0;
+          border-bottom-left-radius: 0;
+        }
+      }
+
+      &:last-child:not(:only-child) {
+        .#{vi.$prefix}button,
+        .#{vi.$prefix}input,
+        .#{vi.$prefix}select select {
+          border-top-left-radius:    0;
+          border-bottom-left-radius: 0;
+        }
+      }
+
+      .#{vi.$prefix}button,
+      .#{vi.$prefix}input,
+      .#{vi.$prefix}select select {
+        &:not([disabled]) {
+          &:hover,
+          &.#{vi.$prefix}is-hovered {
+            z-index: 2;
+          }
+
+          &:focus,
+          &.#{vi.$prefix}is-focused,
+          &:active,
+          &.#{vi.$prefix}is-active {
+            z-index: 3;
+
+            &:hover {
+              z-index: 4;
+            }
+          }
+        }
+      }
+
+      &.#{vi.$prefix}is-expanded {
+        flex-grow:   1;
+        flex-shrink: 0;
+      }
+    }
+
+    &.#{vi.$prefix}has-addons-centered {
+      justify-content: center;
+    }
+
+    &.#{vi.$prefix}has-addons-right {
+      justify-content: flex-end;
+    }
+
+    &.#{vi.$prefix}has-addons-fullwidth {
+      .#{vi.$prefix}control {
+        flex-grow:   1;
+        flex-shrink: 0;
+      }
+    }
+  }
+
+  &.#{vi.$prefix}is-grouped {
+    display:         flex;
+    justify-content: flex-start;
+    gap:             0.75rem;
+
+    & > .#{vi.$prefix}control {
+      flex-shrink: 0;
+
+      &.#{vi.$prefix}is-expanded {
+        flex-grow:   1;
+        flex-shrink: 1;
+      }
+    }
+
+    &.#{vi.$prefix}is-grounded-centered {
+      justify-content: center;
+    }
+
+    &.#{vi.$prefix}is-grouped-right {
+      justify-content: flex-end;
+    }
+
+    &.#{vi.$prefix}is-grouped-multiline {
+      flex-wrap: wrap;
+    }
+  }
+
+  &.#{vi.$prefix}is-horizontal {
+    @include mx.tablet {
+      display: flex;
+    }
+  }
+}
+
+.#{vi.$prefix}field-label {
+  .#{vi.$prefix}label {
+    font-size: inherit;
+  }
+
+  @include mx.mobile {
+    margin-bottom: 0.5rem;
+  }
+
+  @include mx.tablet {
+    flex-basis:        0;
+    flex-grow:         1;
+    flex-shrink:       0;
+    text-align:        right;
+    margin-inline-end: 1.5rem;
+
+    &.#{vi.$prefix}is-small {
+      padding-top: 0.375em;
+      font-size:   vs.getVar("size-small");
+    }
+
+    &.#{vi.$prefix}is-normal {
+      padding-top: 0.375em;
+    }
+
+    &.#{vi.$prefix}is-medium {
+      padding-top: 0.375em;
+      font-size:   vs.getVar("size-medium");
+    }
+
+    &.#{vi.$prefix}is-large {
+      padding-top: 0.375em;
+      font-size:   vs.getVar("size-large");
+    }
+  }
+}
+
+.#{vi.$prefix}field-body {
+  .#{vi.$prefix}field .#{vi.$prefix}field {
+    margin-bottom: 0;
+  }
+
+  @include mx.tablet {
+    display:     flex;
+    flex-basis:  0;
+    flex-grow:   5;
+    flex-shrink: 1;
+
+    .#{vi.$prefix}field {
+      margin-bottom: 0;
+    }
+
+    & > .#{vi.$prefix}field {
+      flex-shrink: 1;
+
+      &:not(.#{vi.$prefix}is-narrow) {
+        flex-grow: 1;
+      }
+
+      &:not(:last-child) {
+        margin-inline-end: 0.75rem;
+      }
+    }
+  }
+}
+
+.#{vi.$prefix}control {
+  position:   relative;
+  clear:      both;
+  text-align: inherit;
+  box-sizing: border-box;
+  font-size:  vs.getVar("size-normal");
+
+  // modifiers
+  &.#{vi.$prefix}has-icon-left,
+  &.#{vi.$prefix}has-icon-right {
+    .#{vi.$prefix}input,
+    .#{vi.$prefix}select select {
+      &:hover {}
+
+      &:focus {}
+
+      &.#{vi.$prefix}is-small ~ .#{vi.$prefix}icon {
+        font-size: vs.getVar("size-small");
+      }
+
+      &.#{vi.$prefix}is-normal ~ .#{vi.$prefix}icon {}
+
+      &.#{vi.$prefix}is-medium ~ .#{vi.$prefix}icon {
+        font-size: vs.getVar("size-medium");
+      }
+
+      &.#{vi.$prefix}is-large ~ .#{vi.$prefix}icon {
+        font-size: vs.getVar("size-large");
+      }
+    }
+
+    .#{vi.$prefix}icon {
+      position:       absolute;
+      top:            0;
+      z-index:        4;
+      width:          vs.getVar("input-height");
+      height:         vs.getVar("input-height");
+      color:          vs.getVar("input-icon-color");
+      pointer-events: none;
+    }
+  }
+
+  &.#{vi.$prefix}has-icons-left {
+    .#{vi.$prefix}input,
+    .#{vi.$prefix}select select {
+      padding-left: vs.getVar("input-height");
+    }
+
+    .#{vi.$prefix}icon.#{vi.$prefix}is-left {
+      left: 0;
+    }
+  }
+
+  &.#{vi.$prefix}has-icons-right {
+    .#{vi.$prefix}input,
+    .#{vi.$prefix}select select {
+      padding-right: vs.getVar("input-height");
+    }
+
+    .#{vi.$prefix}icon.#{vi.$prefix}is-right {
+      right: 0;
+    }
+  }
+
+  &.#{vi.$prefix}is-loading {
+    &::after {
+      @extend %loader;
+
+      position:         absolute !important;
+      top:              0.75em;
+      inset-inline-end: 0.75em;
+      z-index:          4;
+    }
+
+    &.#{vi.$prefix}is-small:after {
+      font-size: vs.getVar("size-small");
+    }
+
+    &.#{vi.$prefix}is-medium:after {
+      font-size: vs.getVar("size-medium");
+    }
+
+    &.#{vi.$prefix}is-large:after {
+      font-size: vs.getVar("size-large");
+    }
+  }
+}


### PR DESCRIPTION
Added forwarding lines for `input-textarea`, `checkbox-radio`, `select`, `file`, and `tools` in the forms SCSS index file. This allows for enhanced customization and control over the form components in the project.

- [x] Checkbox & radio
- [x] Input & textarea
- [x] Select
- [x] File
- [x] Tools