### PR TITLE
Add element form checkbox and radio styles

### DIFF
--- a/scss/forms/checkbox-radio.scss
+++ b/scss/forms/checkbox-radio.scss
@@ -1,0 +1,15 @@
+@use "shared";
+@use "../configs/variables-init" as vi;
+
+%checkbox-radio {
+  display:     inline-block;
+  position:    relative;
+  cursor:      pointer;
+  line-height: 1.25;
+
+  input{
+    cursor: pointer;
+  }
+
+
+}

--- a/scss/forms/checkbox-radio.scss
+++ b/scss/forms/checkbox-radio.scss
@@ -7,9 +7,26 @@
   cursor:      pointer;
   line-height: 1.25;
 
-  input{
+  input {
     cursor: pointer;
   }
 
+  &[disabled],
+  fieldset[disabled] &,
+  input[disabled] {
+    cursor: not-allowed;
+    color:  shared.$input-disabled-color;
+  }
+}
 
+.#{vi.$prefix}checkbox {
+  @extend %checkbox-radio;
+}
+
+.#{vi.$prefix}radio {
+  @extend %checkbox-radio;
+
+  & + .#{vi.$prefix}radio {
+    margin-inline-start: 0.5em;
+  }
 }


### PR DESCRIPTION
This commit introduces the styles for checkbox and radio form controls in the SCSS stylesheet. It ensures that these controls are displayed as inline-blocks and positioned relative to their parent elements, along with having a custom cursor pointer.