### PR TITLE
Add element form styles for input textarea

### DIFF
--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -5,8 +5,67 @@
 @use "../configs/extends";
 @use "../configs/mixins" as mx;
 
-$textarea-padding: vs.getVar("control-padding-horizontal") !default;
+$textarea-padding:    vs.getVar("control-padding-horizontal") !default;
 $textarea-max-height: 40em !default;
 $textarea-min-height: 8em !default;
 
-$textarea-colors: vd.$colors !default;
+$textarea-colors:     vd.$colors !default;
+
+%input-textarea {
+  @extend %input;
+
+  @include vs.regiser-vars((
+    "input-h": vs.getVar("scheme-h"),
+    "input-s": vs.getVar("scheme-s"),
+    "input-border-style": solid,
+    "input-border-width": 1px,
+    "input-border-l": vs.getVar("border-l")
+  ));
+
+  box-shadow: shared.$input-shadow;
+  max-width:  100%;
+  width:      100%;
+
+  &[readonly] {
+    box-shadow: none;
+  }
+
+  // colors
+  @each $name, $pair in $textarea-colors {
+    $color: nth($pair, 1);
+
+    &.#{vi.$prefix}is-#{$name} {
+      @include vs.register-vars((
+        "input-h": vs.getVar($name, "", "-h"),
+        "input-s": vs.getVar($name, "", "-s"),
+        "input-l": vs.getVar($name, "", "-l"),
+        "input-focus-h": vs.getVar($name, "", "-h"),
+        "input-focus-s": vs.getVar($name, "", "-s"),
+        "input-focus-l": vs.getVar($name, "", "-l"),
+        "input-border-l": vs.getVar($name, "", "-l")
+      ));
+    }
+  }
+
+  // sizes
+  &.#{vi.$prefix}is-small {}
+
+  &.#{vi.$prefix}is-medium {}
+
+  &.#{vi.$prefix}is-large {}
+
+  // modifiers
+  &.#{vi.$prefix}is-fullwidth {
+    display: block;
+    width:   100%;
+  }
+
+  &.#{vi.$prefix}is-inline {
+    display: inline;
+    width:   auto;
+  }
+}
+
+.#{vi.$prefix}input {}
+
+.#{vi.$prefix}textarea {}

--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -73,7 +73,19 @@ $textarea-colors:     vd.$colors !default;
   }
 }
 
-.#{vi.$prefix}input {}
+.#{vi.$prefix}input {
+  @extend %input-textarea;
+
+  &.#{vi.$prefix}is-static {
+    border-color:     transparent;
+    background-color: transparent;
+    box-shadow:       none;
+    padding-left:     0;
+    padding-right:    0;
+  }
+
+  &.#{vi.$prefix}is-rounded {}
+}
 
 .#{vi.$prefix}textarea {
   @extend %input-textarea;

--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -84,7 +84,11 @@ $textarea-colors:     vd.$colors !default;
     padding-right:    0;
   }
 
-  &.#{vi.$prefix}is-rounded {}
+  &.#{vi.$prefix}is-rounded {
+    border-radius: vs.getVar("radius-rounded");
+    padding-left:  calc(#{controls.$control-padding-horizontal} + 0.375em);
+    padding-right: calc(#{controls.$control-padding-horizontal} + 0.375em);
+  }
 }
 
 .#{vi.$prefix}textarea {

--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -75,4 +75,32 @@ $textarea-colors:     vd.$colors !default;
 
 .#{vi.$prefix}input {}
 
-.#{vi.$prefix}textarea {}
+.#{vi.$prefix}textarea {
+  @extend %input-textarea;
+
+  @include vs.register-vars((
+    "textarea-padding": #{$textarea-padding},
+    "textarea-max-height": #{$textarea-max-height},
+    "textarea-min-height": #{$textarea-min-height}
+  ));
+
+  display:   block;
+  max-width: 100%;
+  min-width: 100%;
+  resize:    vertical;
+  padding:   vs.getVar("textarea-padding");
+
+  &:not([rows]) {
+    max-height: vs.getVar("textarea-max-height");
+    min-height: vs.getVar("textarea-min-height");
+  }
+
+  &[rows] {
+    height: inherit;
+  }
+
+  // modifiers
+  &.#{vi.$prefix}has-fixed-size {
+    resize: none;
+  }
+}

--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -3,6 +3,7 @@
 @use "../configs/variables-init" as vi;
 @use "../configs/variables-scss" as vs;
 @use "../configs/extends";
+@use "../configs/controls";
 @use "../configs/mixins" as mx;
 
 $textarea-padding:    vs.getVar("control-padding-horizontal") !default;
@@ -48,11 +49,17 @@ $textarea-colors:     vd.$colors !default;
   }
 
   // sizes
-  &.#{vi.$prefix}is-small {}
+  &.#{vi.$prefix}is-small {
+    @include controls.control-small;
+  }
 
-  &.#{vi.$prefix}is-medium {}
+  &.#{vi.$prefix}is-medium {
+    @include controls.control-medium;
+  }
 
-  &.#{vi.$prefix}is-large {}
+  &.#{vi.$prefix}is-large {
+    @include controls.control-large;
+  }
 
   // modifiers
   &.#{vi.$prefix}is-fullwidth {

--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -1,0 +1,12 @@
+@use "shared";
+@use "../configs/variables-derived" as vd;
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$textarea-padding: vs.getVar("control-padding-horizontal") !default;
+$textarea-max-height: 40em !default;
+$textarea-min-height: 8em !default;
+
+$textarea-colors: vd.$colors !default;


### PR DESCRIPTION
This commit adds styles and configurations for the input textarea component. It includes default variables for padding, max/min height, and colors, allowing for flexible customization.