### PR TITLE
Fix typo in scss forms file

### DIFF
--- a/scss/forms/input-textarea.scss
+++ b/scss/forms/input-textarea.scss
@@ -15,7 +15,7 @@ $textarea-colors:     vd.$colors !default;
 %input-textarea {
   @extend %input;
 
-  @include vs.regiser-vars((
+  @include vs.register-vars((
     "input-h": vs.getVar("scheme-h"),
     "input-s": vs.getVar("scheme-s"),
     "input-border-style": solid,


### PR DESCRIPTION
A typo was found and corrected in the scss file for form input-textarea. Changed "vs.regiser-vars" to "vs.register-vars" to ensure that the SCSS mixins function as expected.