### PR TITLE
Add element form tools

### DIFF
--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -245,7 +245,38 @@ $label-colors: shared.$form-colors !default;
 
   // modifiers
   &.#{vi.$prefix}has-icon-left,
-  &.#{vi.$prefix}has-icon-right {}
+  &.#{vi.$prefix}has-icon-right {
+    .#{vi.$prefix}input,
+    .#{vi.$prefix}select select {
+      &:hover {}
+
+      &:focus {}
+
+      &.#{vi.$prefix}is-small ~ .#{vi.$prefix}icon {
+        font-size: vs.getVar("size-small");
+      }
+
+      &.#{vi.$prefix}is-normal ~ .#{vi.$prefix}icon {}
+
+      &.#{vi.$prefix}is-medium ~ .#{vi.$prefix}icon {
+        font-size: vs.getVar("size-medium");
+      }
+
+      &.#{vi.$prefix}is-large ~ .#{vi.$prefix}icon {
+        font-size: vs.getVar("size-large");
+      }
+    }
+
+    .#{vi.$prefix}icon {
+      position:       absolute;
+      top:            0;
+      z-index:        4;
+      width:          vs.getVar("input-height");
+      height:         vs.getVar("input-height");
+      color:          vs.getVar("input-icon-color");
+      pointer-events: none;
+    }
+  }
 
   &.#{vi.$prefix}has-icons-left {
     .#{vi.$prefix}input,

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -120,11 +120,20 @@ $label-colors: shared.$form-colors !default;
       }
     }
 
-    &.#{vi.$prefix}has-addons-centered {}
+    &.#{vi.$prefix}has-addons-centered {
+      justify-content: center;
+    }
 
-    &.#{vi.$prefix}has-addons-right {}
+    &.#{vi.$prefix}has-addons-right {
+      justify-content: flex-end;
+    }
 
-    &.#{vi.$prefix}has-addons-fullwidth {}
+    &.#{vi.$prefix}has-addons-fullwidth {
+      .#{vi.$prefix}control {
+        flex-grow:   1;
+        flex-shrink: 0;
+      }
+    }
   }
 
   &.#{vi.$prefix}is-grouped {}

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -249,7 +249,16 @@ $label-colors: shared.$form-colors !default;
 
   &.#{vi.$prefix}has-icons-left {}
 
-  &.#{vi.$prefix}has-icons-right {}
+  &.#{vi.$prefix}has-icons-right {
+    .#{vi.$prefix}input,
+    .#{vi.$prefix}select select {
+      padding-right: vs.getVar("input-height");
+    }
+
+    .#{vi.$prefix}icon.#{vi.$prefix}is-right {
+      right: 0;
+    }
+  }
 
   &.#{vi.$prefix}is-loading {
     &::after {

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -170,7 +170,42 @@ $label-colors: shared.$form-colors !default;
   }
 }
 
-.#{vi.$prefix}field-label {}
+.#{vi.$prefix}field-label {
+  .#{vi.$prefix}label {
+    font-size: inherit;
+  }
+
+  @include mx.mobile {
+    margin-bottom: 0.5rem;
+  }
+
+  @include mx.tablet {
+    flex-basis:        0;
+    flex-grow:         1;
+    flex-shrink:       0;
+    text-align:        right;
+    margin-inline-end: 1.5rem;
+
+    &.#{vi.$prefix}is-small {
+      padding-top: 0.375em;
+      font-size:   vs.getVar("size-small");
+    }
+
+    &.#{vi.$prefix}is-normal {
+      padding-top: 0.375em;
+    }
+
+    &.#{vi.$prefix}is-medium {
+      padding-top: 0.375em;
+      font-size:   vs.getVar("size-medium");
+    }
+
+    &.#{vi.$prefix}is-large {
+      padding-top: 0.375em;
+      font-size:   vs.getVar("size-large");
+    }
+  }
+}
 
 .#{vi.$prefix}field-body {}
 

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -207,6 +207,33 @@ $label-colors: shared.$form-colors !default;
   }
 }
 
-.#{vi.$prefix}field-body {}
+.#{vi.$prefix}field-body {
+  .#{vi.$prefix}field .#{vi.$prefix}field {
+    margin-bottom: 0;
+  }
+
+  @include mx.tablet {
+    display:     flex;
+    flex-basis:  0;
+    flex-grow:   5;
+    flex-shrink: 1;
+
+    .#{vi.$prefix}field {
+      margin-bottom: 0;
+    }
+
+    & > .#{vi.$prefix}field {
+      flex-shrink: 1;
+
+      &:not(.#{vi.$prefix}is-narrow) {
+        flex-grow: 1;
+      }
+
+      &:not(:last-child) {
+        margin-inline-end: 0.75rem;
+      }
+    }
+  }
+}
 
 .#{vi.$prefix}control {}

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -247,7 +247,16 @@ $label-colors: shared.$form-colors !default;
   &.#{vi.$prefix}has-icon-left,
   &.#{vi.$prefix}has-icon-right {}
 
-  &.#{vi.$prefix}has-icons-left {}
+  &.#{vi.$prefix}has-icons-left {
+    .#{vi.$prefix}input,
+    .#{vi.$prefix}select select {
+      padding-left: vs.getVar("input-height");
+    }
+
+    .#{vi.$prefix}icon.#{vi.$prefix}is-left {
+      left: 0;
+    }
+  }
 
   &.#{vi.$prefix}has-icons-right {
     .#{vi.$prefix}input,

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -35,7 +35,17 @@ $label-colors: shared.$form-colors !default;
   }
 }
 
-.#{vi.$prefix}help {}
+.#{vi.$prefix}help {
+  display:    block;
+  margin-top: 0.25rem;
+  font-size:  $help-size;
+
+  @each $name, $pair in $label-colors {
+    &.#{vi.$prefix}is-#{$name} {
+      color: hsl(#{vs.getVar($name, "", "-h")}, #{vs.getVar($name, "", "-s")}, #{vs.getVar($name, "", "-on-scheme-l")});
+    }
+  }
+}
 
 // containers
 

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -163,7 +163,11 @@ $label-colors: shared.$form-colors !default;
     }
   }
 
-  &.#{vi.$prefix}is-horizontal {}
+  &.#{vi.$prefix}is-horizontal {
+    @include mx.tablet {
+      display: flex;
+    }
+  }
 }
 
 .#{vi.$prefix}field-label {}

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -49,7 +49,67 @@ $label-colors: shared.$form-colors !default;
 
 // containers
 
-.#{vi.$prefix}field {}
+.#{vi.$prefix}field {
+  @include vs.register-vars((
+    "block-spacing": 0.75rem,
+  ));
+
+  @extend %block;
+
+  // modifiers
+  &.#{vi.$prefix}has-addons {
+    display:         flex;
+    justify-content: flex-start;
+
+    .#{vi.$prefix}control {
+      &:not(:last-child) {}
+
+      &:not(:first-child):not(:last-child) {}
+
+      &:first-child:not(:only-child) {}
+
+      &:last-child:not(:only-child) {}
+
+      .#{vi.$prefix}button,
+      .#{vi.$prefix}input,
+      .#{vi.$prefix}select select {
+        &:not([disabled]) {
+          &:hover,
+          &.#{vi.$prefix}is-hovered {
+            z-index: 2;
+          }
+
+          &:focus,
+          &.#{vi.$prefix}is-focused,
+          &:active,
+          &.#{vi.$prefix}is-active {
+            z-index: 3;
+
+            &:hover {
+              z-index: 4;
+
+            }
+          }
+        }
+      }
+
+      &.#{vi.$prefix}is-expanded {
+        flex-grow:   1;
+        flex-shrink: 0;
+      }
+    }
+
+    &.#{vi.$prefix}has-addons-centered {}
+
+    &.#{vi.$prefix}has-addons-right {}
+
+    &.#{vi.$prefix}has-addons-fullwidth {}
+  }
+
+  &.#{vi.$prefix}is-grouped {}
+
+  &.#{vi.$prefix}is-horizontal {}
+}
 
 .#{vi.$prefix}field-label {}
 

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -136,7 +136,32 @@ $label-colors: shared.$form-colors !default;
     }
   }
 
-  &.#{vi.$prefix}is-grouped {}
+  &.#{vi.$prefix}is-grouped {
+    display:         flex;
+    justify-content: flex-start;
+    gap:             0.75rem;
+
+    & > .#{vi.$prefix}control {
+      flex-shrink: 0;
+
+      &.#{vi.$prefix}is-expanded {
+        flex-grow:   1;
+        flex-shrink: 1;
+      }
+    }
+
+    &.#{vi.$prefix}is-grounded-centered {
+      justify-content: center;
+    }
+
+    &.#{vi.$prefix}is-grouped-right {
+      justify-content: flex-end;
+    }
+
+    &.#{vi.$prefix}is-grouped-multiline {
+      flex-wrap: wrap;
+    }
+  }
 
   &.#{vi.$prefix}is-horizontal {}
 }

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -236,4 +236,41 @@ $label-colors: shared.$form-colors !default;
   }
 }
 
-.#{vi.$prefix}control {}
+.#{vi.$prefix}control {
+  position:   relative;
+  clear:      both;
+  text-align: inherit;
+  box-sizing: border-box;
+  font-size:  vs.getVar("size-normal");
+
+  // modifiers
+  &.#{vi.$prefix}has-icon-left,
+  &.#{vi.$prefix}has-icon-right {}
+
+  &.#{vi.$prefix}has-icons-left {}
+
+  &.#{vi.$prefix}has-icons-right {}
+
+  &.#{vi.$prefix}is-loading {
+    &::after {
+      @extend %loader;
+
+      position:         absolute !important;
+      top:              0.75em;
+      inset-inline-end: 0.75em;
+      z-index:          4;
+    }
+
+    &.#{vi.$prefix}is-small:after {
+      font-size: vs.getVar("size-small");
+    }
+
+    &.#{vi.$prefix}is-medium:after {
+      font-size: vs.getVar("size-medium");
+    }
+
+    &.#{vi.$prefix}is-large:after {
+      font-size: vs.getVar("size-large");
+    }
+  }
+}

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -1,0 +1,13 @@
+@use "shared";
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$label-color:  vs.getVar("text-strong") !default;
+$label-weight: vs.getVar("weight-semibold") !default;
+
+$help-size:    vs.getVar("size-small") !default;
+
+$label-colors: shared.$form-colors !default;
+

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -64,11 +64,31 @@ $label-colors: shared.$form-colors !default;
     .#{vi.$prefix}control {
       &:not(:last-child) {}
 
-      &:not(:first-child):not(:last-child) {}
+      &:not(:first-child):not(:last-child) {
+        .#{vi.$prefix}button,
+        .#{vi.$prefix}input,
+        .#{vi.$prefix}select select {
+          border-radius: 0;
+        }
+      }
 
-      &:first-child:not(:only-child) {}
+      &:first-child:not(:only-child) {
+        .#{vi.$prefix}button,
+        .#{vi.$prefix}input,
+        .#{vi.$prefix}select select {
+          border-top-left-radius:    0;
+          border-bottom-left-radius: 0;
+        }
+      }
 
-      &:last-child:not(:only-child) {}
+      &:last-child:not(:only-child) {
+        .#{vi.$prefix}button,
+        .#{vi.$prefix}input,
+        .#{vi.$prefix}select select {
+          border-top-left-radius:    0;
+          border-bottom-left-radius: 0;
+        }
+      }
 
       .#{vi.$prefix}button,
       .#{vi.$prefix}input,
@@ -87,7 +107,6 @@ $label-colors: shared.$form-colors !default;
 
             &:hover {
               z-index: 4;
-
             }
           }
         }

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -11,3 +11,38 @@ $help-size:    vs.getVar("size-small") !default;
 
 $label-colors: shared.$form-colors !default;
 
+.#{vi.$prefix}label {
+  display:     block;
+  color:       $label-color;
+  font-size:   vs.getVar("size-normal");
+  font-weight: $label-weight;
+
+  &:not(:last-child) {
+    margin-bottom: 0.5em;
+  }
+
+  // sizes
+  &.#{vi.$prefix}is-small {
+    font-size: vs.getVar("size-small");
+  }
+
+  &.#{vi.$prefix}is-medium {
+    font-size: vs.getVar("size-medium");
+  }
+
+  &.#{vi.$prefix}is-large {
+    font-size: vs.getVar("size-large");
+  }
+}
+
+.#{vi.$prefix}help {}
+
+// containers
+
+.#{vi.$prefix}field {}
+
+.#{vi.$prefix}field-label {}
+
+.#{vi.$prefix}field-body {}
+
+.#{vi.$prefix}control {}

--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -62,7 +62,9 @@ $label-colors: shared.$form-colors !default;
     justify-content: flex-start;
 
     .#{vi.$prefix}control {
-      &:not(:last-child) {}
+      &:not(:last-child) {
+        margin-inline-end: -1px;
+      }
 
       &:not(:first-child):not(:last-child) {
         .#{vi.$prefix}button,


### PR DESCRIPTION
The update introduces SCSS configurations to the form tools file. This includes imports from shared configurations, initial variables, extends, and mixins. Also, variables for label color, label weight, help size and label colors have been defined with default values from the respective configs.

A block of rules for label styling has been added in the `forms/tools.scss` file. Furthermore, empty styling blocks for `.#{vi.$prefix}help`, `.#{vi.$prefix}field`, `.#{vi.$prefix}field-label`, `.#{vi.$prefix}field-body`, and `.#{vi.$prefix}control` have been introduced to serve as containers. The label styles include size variations and color definitions.

The styling for the help text in form elements has been updated. This includes adding block display, setting a margin top, defining the font size, and setting specific color based on label colors.