### PR TITLE
Layout header when desktop

### DIFF
--- a/scss/forms/tools.scss
+++ b/scss/forms/tools.scss
@@ -244,8 +244,8 @@ $label-colors: shared.$form-colors !default;
   font-size:  vs.getVar("size-normal");
 
   // modifiers
-  &.#{vi.$prefix}has-icon-left,
-  &.#{vi.$prefix}has-icon-right {
+  &.#{vi.$prefix}has-icons-left,
+  &.#{vi.$prefix}has-icons-right {
     .#{vi.$prefix}input,
     .#{vi.$prefix}select select {
       &:hover {}

--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -248,7 +248,7 @@ header,
                                 calc(#{vs.getVar("header-item-background-l")} + #{vs.getVar("header-item-background-l-delta")})
                             );
 
-          &.#{vi.$prefix}is-active
+          &.#{vi.$prefix}is-active,
           &.#{vi.$prefix}is-selected {
             @include vs.register-vars((
               "header-h": #{vs.getVar("header-item-selected-h")},
@@ -260,6 +260,36 @@ header,
           }
         }
       }
+    }
+  }
+
+  .#{vi.$prefix}header-burger {}
+
+  .#{vi.$prefix}header-item,
+  .#{vi.$prefix}header-link {}
+
+  .#{vi.$prefix}header-item {}
+
+  .#{vi.$prefix}header-menu {}
+
+  .#{vi.$prefix}header-start {}
+
+  .#{vi.$prefix}header-end {}
+
+  .#{vi.$prefix}header-dropdown {}
+
+  .#{vi.$prefix}header-divider {}
+
+  header > .#{vi.$prefix}container,
+  .#{vi.$prefix}header > .#{vi.$prefix}container,
+  .#{vi.$prefix}container > header,
+  .#{vi.$prefix}container > .#{vi.$prefix}header {
+    .#{vi.$prefix}header-brand {
+      margin-inline-start: -0.75em;
+    }
+
+    .#{vi.$prefix}header-menu {
+      margin-inline-end: -0.75em;
     }
   }
 }

--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -239,6 +239,27 @@ header,
       @include vs.register-vars((
         "header-item-background-a": 0,
       ));
+
+      .#{vi.$prefix}header-dropdown {
+        a.#{vi.$prefix}header-item {
+          background-color: hsl(
+                                #{vs.getVar("header-h")},
+                                #{vs.getVar("header-s")},
+                                calc(#{vs.getVar("header-item-background-l")} + #{vs.getVar("header-item-background-l-delta")})
+                            );
+
+          &.#{vi.$prefix}is-active
+          &.#{vi.$prefix}is-selected {
+            @include vs.register-vars((
+              "header-h": #{vs.getVar("header-item-selected-h")},
+              "header-s": #{vs.getVar("header-item-selected-s")},
+              "header-l": #{vs.getVar("header-item-selected-l")},
+              "header-item-background-l": #{vs.getVar("header-item-selected-background-l")},
+              "header-item-color-l": #{vs.getVar("header-item-selected-color-l")},
+            ));
+          }
+        }
+      }
     }
   }
 }

--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -292,5 +292,14 @@ header,
       margin-inline-end: -0.75em;
     }
   }
+
+  // fixed header
+  header,
+  .#{vi.$prefix}header {
+
+  }
+
+  html,
+  body {}
 }
 

--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -272,9 +272,15 @@ header,
 
   .#{vi.$prefix}header-menu {}
 
-  .#{vi.$prefix}header-start {}
+  .#{vi.$prefix}header-start {
+    justify-content:   flex-start;
+    margin-inline-end: auto;
+  }
 
-  .#{vi.$prefix}header-end {}
+  .#{vi.$prefix}header-end {
+    justify-content:     flex-end;
+    margin-inline-start: auto;
+  }
 
   .#{vi.$prefix}header-dropdown {}
 

--- a/scss/themes/dark.scss
+++ b/scss/themes/dark.scss
@@ -10,7 +10,7 @@
 // The main lightness of the theme
 $scheme-main-l: 4%;
 $background-l:  5%;
-$text-l:        90%;
+$text-l:        98%;
 
 // The main scheme color, used to make calculations
 $scheme-main:   hsl(vi.$scheme-h, vi.$scheme-s, $scheme-main-l);

--- a/templates/accouter/layout/_master.tmpl
+++ b/templates/accouter/layout/_master.tmpl
@@ -81,16 +81,16 @@
     {{^_disableNavbar}}
       <nav class="" role="navigation">
         <div class="header-start">
-          <form action="./" method="get" autocomplete="off" novalidate>
-            <div class="field has-addons">
-              <div class="control has-icon-left">
+          <div class="field has-addons">
+            <div class="control has-icon-left">
+              <form action="./" method="get" autocomplete="off" novalidate>
               <span class="icon is-left">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"></path><path d="M21 21l-6 -6"></path></svg>
               </span>
                 <input class="input" type="text" value="" placeholder="Search" aria-label="Search admin portal">
-              </div>
+              </form>
             </div>
-          </form>
+          </div>
         </div>
       </nav>
     {{/_disableNavbar}}

--- a/templates/accouter/layout/_master.tmpl
+++ b/templates/accouter/layout/_master.tmpl
@@ -83,14 +83,17 @@
         <div class="header-start">
           <div class="field has-addons">
             <div class="control has-icons-left">
-              <!--              <form action="./" method="get" autocomplete="off" novalidate>-->
+              <!--<form action="./" method="get" autocomplete="off" novalidate>-->
               <input class="input" type="text" value="" placeholder="Search" aria-label="Search admin portal">
               <span class="icon is-left">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"></path><path d="M21 21l-6 -6"></path></svg>
               </span>
-              <!--              </form>-->
+              <!--</form>-->
             </div>
           </div>
+        </div>
+        <div class="header-end">
+
         </div>
       </nav>
     {{/_disableNavbar}}

--- a/templates/accouter/layout/_master.tmpl
+++ b/templates/accouter/layout/_master.tmpl
@@ -82,13 +82,13 @@
       <nav class="" role="navigation">
         <div class="header-start">
           <div class="field has-addons">
-            <div class="control has-icon-left">
-              <form action="./" method="get" autocomplete="off" novalidate>
+            <div class="control has-icons-left">
+              <!--              <form action="./" method="get" autocomplete="off" novalidate>-->
+              <input class="input" type="text" value="" placeholder="Search" aria-label="Search admin portal">
               <span class="icon is-left">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"></path><path d="M21 21l-6 -6"></path></svg>
               </span>
-                <input class="input" type="text" value="" placeholder="Search" aria-label="Search admin portal">
-              </form>
+              <!--              </form>-->
             </div>
           </div>
         </div>


### PR DESCRIPTION
This commit introduces new SCSS rules to define the background colour for active and selected items in the header dropdown. It specifically registers the variables for hue, saturation, and lightness for selected header items, providing a visual distinction.