### PR TITLE
Update 'docfx' script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build-scss && npm run build-minify",
     "build-scss": "sass --style=expanded --source-map accouter.scss css/accouter.css",
     "build-minify": "postcss css/accouter.css --no-map --use cssnano --output css/accouter.min.css",
-    "docfx": "npm-run-all docfx-style docfx-serve",
+    "docfx": "npm-run-all docfx-style docfx-build",
     "docfx-style": "cpy css/accouter.* templates/accouter/public/ --flat",
     "docfx-build": "docfx build docfx.json --logLevel error",
     "docfx-serve": "docfx build docfx.json --serve --logLevel error",


### PR DESCRIPTION
The 'docfx' script has been updated in the package.json file. Previously, it was set to run 'docfx-style' and 'docfx-serve' scripts. With this change, it now runs 'docfx-style' and 'docfx-build' scripts.