### PR TITLE
Add color customization to header layout

### DIFF
--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -181,6 +181,16 @@ header,
         "header-item-selected-h": #{vs.getVar($name, "", "-h")},
         "header-item-selected-s": #{vs.getVar($name, "", "-s")},
         "header-item-selected-l": #{vs.getVar($name, "", "-l")},
+        "header-item-selected-background-l": #{vs.getVar($name, "", "-l")},
+        "header-item-selected-color-l": #{vs.getVar($name, "", "-invert-l")},
+        "header-dropdown-item-h": #{vs.getVar($name, "", "-h")},
+        "header-dropdown-item-s": #{vs.getVar($name, "", "-s")},
+        "header-dropdown-arrow": #{vs.getVar($name, "", "-invert-l")},
+        "header-dropdown-background-color": hsl(
+            #{vs.getVar($name, "", "-h")},
+            #{vs.getVar($name, "", "-s")},
+            #{vs.getVar("header-dropdown-item-background-l")}
+        ),
       ));
     }
   }

--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -166,6 +166,25 @@ header,
   background-color: vs.getVar("header-background-color");
   z-index:          vs.getVar("header-z-index");
 
+  @each $name, $pair in $header-colors {
+    &.#{vi.$prefix}is-#{$name} {
+      @include vs.register-vars((
+        "header-h": #{vs.getVar($name, "", "-h")},
+        "header-s": #{vs.getVar($name, "", "-s")},
+        "header-l": #{vs.getVar($name, "", "-l")},
+        "burger-h": #{vs.getVar($name, "", "-h")},
+        "burger-s": #{vs.getVar($name, "", "-s")},
+        "burger-l": #{vs.getVar($name, "", "-l")},
+        "header-background-color": #{vs.getVar($name)},
+        "header-item-background-l": #{vs.getVar($name, "", "-l")},
+        "header-item-color-l": #{vs.getVar($name, "", "-invert-l")},
+        "header-item-selected-h": #{vs.getVar($name, "", "-h")},
+        "header-item-selected-s": #{vs.getVar($name, "", "-s")},
+        "header-item-selected-l": #{vs.getVar($name, "", "-l")},
+      ));
+    }
+  }
+
   @include mx.desktop {
     margin-left: vs.getVar("sidebar-width");
   }


### PR DESCRIPTION
A new logic to allow various color customization options for the header layout has been added. The implemented loop goes through each color in the color list `$header-colors` and applies the selected values to define header and burger variants including their background and selected item colors.