### PR TITLE
Refactor layout header nav styles

### DIFF
--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -207,18 +207,23 @@ header,
     min-height:  vs.getVar("header-height");
     align-items: stretch;
 
-    .#{vi.$prefix}header-brand {
-      display:     inline-flex;
-      align-items: center;
-      line-height: 1;
-      gap:         vs.getVar("header-brand-gap");
-      font-weight: vs.getVar("header-brand-font-weight");
-      font-size:   vs.getVar("header-brand-font-size");
-      color:       vs.getVar("header-brand-color");
-      margin:      0;
-      white-space: nowrap;
+    & > .#{vi.$prefix}container{
+      align-items: stretch;
+
     }
   }
+}
+
+.#{vi.$prefix}header-brand {
+  display:     inline-flex;
+  align-items: center;
+  line-height: 1;
+  gap:         vs.getVar("header-brand-gap");
+  font-weight: vs.getVar("header-brand-font-weight");
+  font-size:   vs.getVar("header-brand-font-size");
+  color:       vs.getVar("header-brand-color");
+  margin:      0;
+  white-space: nowrap;
 }
 
 @include mx.until($header-breakpoint) {

--- a/scss/layouts/header.scss
+++ b/scss/layouts/header.scss
@@ -203,13 +203,36 @@ header,
   .#{vi.$prefix}nav {
     display:     flex;
     position:    relative;
+    align-items: stretch;
     width:       100%;
     min-height:  vs.getVar("header-height");
-    align-items: stretch;
 
-    & > .#{vi.$prefix}container{
+    & > .#{vi.$prefix}container {
+      display:     flex;
       align-items: stretch;
+      width:       100%;
+      min-height:  vs.getVar("header-height");
+    }
 
+    &.#{vi.$prefix}has-shadow {
+      box-shadow: vs.getVar("header-box-shadow-size") vs.getVar("header-box-shadow-color");
+    }
+
+    &.#{vi.$prefix}is-fixed-top,
+    &.#{vi.$prefix}is-fixed-bottom {
+      @include header-fixed;
+    }
+
+    &.#{vi.$prefix}is-fixed-top {
+      top: 0;
+    }
+
+    &.#{vi.$prefix}is-fixed-bottom {
+      bottom: 0;
+
+      &.#{vi.$prefix}has-shadow {
+        box-shadow: vs.getVar("header-bottom-box-shadow-size") vs.getVar("header-box-shadow-color");
+      }
     }
   }
 }

--- a/scss/layouts/nav.scss
+++ b/scss/layouts/nav.scss
@@ -4,12 +4,24 @@
 @use "../configs/extends";
 @use "../configs/mixins" as mx;
 
-$nav-height: 3.5rem !default;
+$nav-height:             3.5rem !default;
+$nav-padding-vertical:   0.5rem !default;
+$nav-padding-horizontal: 1rem !default;
+$nav-z-index:            20 !default;
+$nav-fixed-z-index:      20 !default;
 
 :root {
   @include vs.register-vars((
-    "navbar-height" : #{$nav-height},
+    "nav-height" : #{$nav-height},
   ));
 }
 
-nav {}
+nav,
+.#{vi.$prefix}nav {
+  @include vs.register-vars((
+    "nav-padding-vertical" : #{$nav-padding-vertical},
+    "nav-padding-horizontal" : #{$nav-padding-horizontal},
+    "nav-z-index" : #{$nav-z-index},
+    "nav-fixed-z-index" : #{$nav-fixed-z-index},
+  ));
+}

--- a/scss/layouts/nav.scss
+++ b/scss/layouts/nav.scss
@@ -1,1 +1,15 @@
-nav{}
+@use "../configs/variables-scss" as vs;
+@use "../configs/variables-derived" as vd;
+@use "../configs/variables-init" as vi;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$nav-height: 3.5rem !default;
+
+:root {
+  @include vs.register-vars((
+    "navbar-height" : #{$nav-height},
+  ));
+}
+
+nav {}


### PR DESCRIPTION
The header styles have been refactored in the SCSS stylesheet. The class '.header-brand' has been moved outside of the outer selector for better readability and maintainability. 'Align-items: stretch;' has been added to the .container child selector.