### PR TITLE
Add component card

### DIFF
--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -64,4 +64,22 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
 
     &-icon {}
   }
+
+  &-image {
+    &:first-child {}
+
+    &:last-child {}
+  }
+
+  &-content {}
+
+  &-footer {
+    &-item {
+      &:not(:last-child) {}
+    }
+  }
+}
+
+.#{vi.$prefix}card {
+  .#{vi.$prefix}media:not(:last-child) {}
 }

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -103,9 +103,22 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
   }
 
   &-image {
-    &:first-child {}
+    display:  block;
+    position: relative;
 
-    &:last-child {}
+    &:first-child {
+      img {
+        border-start-start-radius: vs.getVar("card-radius");
+        border-start-end-radius:   vs.getVar("card-radius");
+      }
+    }
+
+    &:last-child {
+      img {
+        border-end-start-radius: vs.getVar("card-radius");
+        border-end-end-radius:   vs.getVar("card-radius");
+      }
+    }
   }
 
   &-content {}

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -128,8 +128,24 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
   }
 
   &-footer {
+    @extend %card-item;
+    display:          flex;
+    align-items:      stretch;
+    background-color: vs.getVar("card-footer-background-color");
+    border-top:       vs.getVar("card-footer-border-top");
+
     &-item {
-      &:not(:last-child) {}
+      display:         flex;
+      align-items:     center;
+      justify-content: center;
+      flex-basis:      0;
+      flex-grow:       1;
+      flex-shrink:     0;
+      padding:         vs.getVar("card-footer-padding");
+
+      &:not(:last-child) {
+        border-inline-end: vs.getVar("card-footer-border-top");
+      }
     }
   }
 }

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -50,7 +50,6 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
 
 .#{vi.$prefix}card {
   @extend %block;
-
   position:         relative;
   max-width:        100%;
   color:            vs.getVar("card-color");
@@ -73,11 +72,34 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
 
 .#{vi.$prefix}card {
   &-header {
+    @extend %card-item;
+    display:          flex;
+    align-items:      stretch;
+    background-color: vs.getVar("card-header-background-color");
+    box-shadow:       vs.getVar("card-header-shadow");
+
     &-title {
-      &.#{vi.$prefix}is-centered {}
+      display:     flex;
+      flex-grow:   1;
+      align-items: center;
+      padding:     vs.getVar("card-header-padding");
+      color:       vs.getVar("card-header-color");
+      font-weight: vs.getVar("card-header-weight");
+
+      &.#{vi.$prefix}is-centered {
+        justify-content: center;
+      }
     }
 
-    &-icon {}
+    &-icon {
+      @include mx.reset;
+
+      display:         flex;
+      align-items:     center;
+      justify-content: center;
+      cursor:          pointer;
+      padding:         vs.getVar("card-header-padding");
+    }
   }
 
   &-image {

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -47,3 +47,21 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
     "card-media-margin": $card-media-margin,
   ));
 }
+
+.#{vi.$prefix}card {}
+
+%card-item {
+  &:first-child {}
+
+  &:last-child {}
+}
+
+.#{vi.$prefix}card {
+  &-header {
+    &-title {
+      &.#{vi.$prefix}is-centered {}
+    }
+
+    &-icon {}
+  }
+}

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -151,5 +151,7 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
 }
 
 .#{vi.$prefix}card {
-  .#{vi.$prefix}media:not(:last-child) {}
+  .#{vi.$prefix}media:not(:last-child) {
+    margin-bottom: vs.getVar("card-media-margin");
+  }
 }

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -1,0 +1,29 @@
+@use "../configs/variables-init" as vi;
+@use "../configs/variables-scss" as vs;
+@use "../configs/extends";
+@use "../configs/mixins" as mx;
+
+$card-color:                    vs.getVar("text") !default;
+$card-background-color:         vs.getVar("scheme-main") !default;
+$card-shadow:                   vs.getVar("shadow") !default;
+$card-radius:                   0.75rem !default;
+
+$card-header-background-color:  transparent !default;
+$card-header-color:             vs.getVar("text-strong") !default;
+$card-header-weight:            vs.getVar("weight-bold") !default;
+$card-header-padding:           0.75rem 1rem !default;
+$card-header-shadow:            0 0.125em 0.25em hsla(
+                                    #{vs.getVar("scheme-h")},
+                                    #{vs.getVar("scheme-s")},
+                                    #{vs.getVar("scheme-invert-l")},
+                                    0.1
+                                ) !default;
+
+$card-content-background-color: transparent !default;
+$card-content-padding:          1.5rem !default;
+
+$card-footer-background-color:  transparent !default;
+$card-footer-border-top:        1px solid vs.getVar("border-weak") !default;
+$card-footer-padding:           0.75rem !default;
+
+$card-media-margin:             vs.getVar("block-spacing") !default;

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -27,3 +27,23 @@ $card-footer-border-top:        1px solid vs.getVar("border-weak") !default;
 $card-footer-padding:           0.75rem !default;
 
 $card-media-margin:             vs.getVar("block-spacing") !default;
+
+.#{vi.$prefix}card {
+  @include vs.register-vars((
+    "card-color": $card-color,
+    "card-background-color": $card-background-color,
+    "card-shadow": $card-shadow,
+    "card-radius": $card-radius,
+    "card-header-background-color": $card-header-background-color,
+    "card-header-color": $card-header-color,
+    "card-header-padding": $card-header-padding,
+    "card-header-shadow": $card-header-shadow,
+    "card-header-weight": $card-header-weight,
+    "card-content-background-color": $card-content-background-color,
+    "card-content-padding": $card-content-padding,
+    "card-footer-background-color": $card-footer-background-color,
+    "card-footer-border-top": $card-footer-border-top,
+    "card-footer-padding": $card-footer-padding,
+    "card-media-margin": $card-media-margin,
+  ));
+}

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -121,7 +121,11 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
     }
   }
 
-  &-content {}
+  &-content {
+    @extend %card-item;
+    background-color: vs.getVar("card-content-background-color");
+    padding:          vs.getVar("card-content-padding");
+  }
 
   &-footer {
     &-item {

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -60,9 +60,15 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
 }
 
 %card-item {
-  &:first-child {}
+  &:first-child {
+    border-start-start-radius: vs.getVar("card-radius");
+    border-start-end-radius:   vs.getVar("card-radius");
+  }
 
-  &:last-child {}
+  &:last-child {
+    border-end-start-radius: vs.getVar("card-radius");
+    border-end-end-radius:   vs.getVar("card-radius");
+  }
 }
 
 .#{vi.$prefix}card {

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -48,7 +48,16 @@ $card-media-margin:             vs.getVar("block-spacing") !default;
   ));
 }
 
-.#{vi.$prefix}card {}
+.#{vi.$prefix}card {
+  @extend %block;
+
+  position:         relative;
+  max-width:        100%;
+  color:            vs.getVar("card-color");
+  background-color: vs.getVar("card-background-color");
+  border-radius:    vs.getVar("card-radius");
+  box-shadow:       vs.getVar("card-shadow");
+}
 
 %card-item {
   &:first-child {}


### PR DESCRIPTION
Extended the card component styles in the SCSS file. Newly added styles include adjustment for the first and last card items, and the addition of centered title and icon in the card header.

Added several new styling hooks in the card.scss file. These hooks will allow for more flexible and nuanced styling of the card component, including the image, content, footer and media subsections.

A series of style properties have been added to the card component in the SCSS file. These properties include position, maximum width, color, background-color, border-radius, and box-shadow. Now, cards will have these specific styles applied universally.

In order to enhance the UI, the diff introduces border radius to the first and last child of card items in the SCSS file. The changes make use of the existing "card-radius" variable to ensure consistency across the design.