### PR TITLE
Update docfx script in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Documentation is available as a part of Accouter preview: https://accouter.dev/d
 To run the documentation site locally, follow instructions in the [Documentation README](https://github.com/accouter/accouter/blob/main/README.md).
 
 ```bash
-npm run docfx
+npm run start
 ```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "watch-scss": "nodemon -x 'npm run build'  --config nodemon-scss.json",
     "watch-style": "nodemon -x 'npm run docfx-style' --config nodemon-style.json",
     "watch-serve": "nodemon -x 'npm run docfx-serve' --config nodemon-serve.json",
-    "watch-browser": "browser-sync start --server _site/ --port 8080 --no-open --files='_site/*'"
+    "watch-browser": "browser-sync start --server _site/ --port 8080 --no-open --files='_site/*'",
+    "start": "npm-run-all clean build docfx-style docfx"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build-scss && npm run build-minify",
     "build-scss": "sass --style=expanded --source-map accouter.scss css/accouter.css",
     "build-minify": "postcss css/accouter.css --no-map --use cssnano --output css/accouter.min.css",
-    "docfx": "npm-run-all docfx-style docfx-serve",
+    "docfx": "npm-run-all docfx-style docfx-build",
     "docfx-style": "cpy css/accouter.* templates/accouter/public/ --flat",
     "docfx-build": "docfx build docfx.json --logLevel error",
     "docfx-serve": "docfx build docfx.json --serve --logLevel error",


### PR DESCRIPTION
The `docfx` script in package.json has been modified. It no longer includes the `docfx-serve` command and instead now includes the `docfx-build` command. This change adjusts the tasks run as part of the `docfx` script.

The start instruction in the README.md file and a new script command have been added in package.json file. This update replaces `npm run docfx` with `npm run start` to start the documentation site locally. The 'start' script combines several actions such as 'clean', 'build', 'docfx-style', and 'docfx'.