### PR TITLE
Enable grid styles import in SCSS

### DIFF
--- a/scss/_index.scss
+++ b/scss/_index.scss
@@ -4,6 +4,6 @@
 @forward "elements";
 @forward "forms";
 @forward "components";
-//@forward "grid";
+@forward "grid";
 @forward "helpers";
 @forward "layouts";


### PR DESCRIPTION
The commented out grid styles import in "_index.scss" has been uncommented. This change facilitates using grid styles in the project.